### PR TITLE
fix(workflow): assign Copilot via GraphQL replaceActorsForAssignable

### DIFF
--- a/.github/workflows/sync-from-docs.yml
+++ b/.github/workflows/sync-from-docs.yml
@@ -73,28 +73,37 @@ jobs:
             --arg services "$CHANGED_SERVICES" \
             '"The upstream Docs have been updated. Ensure the affected API documentation in this monorepo is in sync.\n\n## Changed Services\n\n`" + $services + "`\n\n## Recent Docs Changes\n\n```\n" + $changes + "\n```\n\n## Instructions\n\nThis is a monorepo with API documentation in subdirectories (luma/, suno/, etc.).\n\nCheck the AceDataCloud/Docs repo for guides and OpenAPI specs.\n\nCompare against the corresponding subdirectory'\''s docs/ markdown files. Update any outdated information.\n\nOnly modify subdirectories matching the changed services. If everything is already in sync, close this issue."')
 
-          ISSUE_NUM=$(jq -n \
+          ISSUE_JSON=$(jq -n \
             --arg title "sync: update from Docs ($COMMIT_INFO)" \
             --argjson body "$body" \
-            --arg repo "$REPO" \
-            '{
-              title: $title,
-              body: $body,
-              labels: ["auto-sync"],
-              assignees: ["copilot-swe-agent[bot]"],
-              agent_assignment: {
-                target_repo: $repo,
-                base_branch: "main",
-                custom_instructions: "Check out the AceDataCloud/Docs repo. This is a monorepo — each subdirectory (luma/, suno/, etc.) contains API documentation. Update the docs/ markdown files to match the latest Docs content. If everything is already in sync, close this issue."
-              }
-            }' | gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/"$REPO"/issues \
-            --input - --jq '.number')
+            '{title: $title, body: $body, labels: ["auto-sync"]}' \
+            | gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /repos/"$REPO"/issues \
+              --input -)
+          ISSUE_NUM=$(echo "$ISSUE_JSON" | jq -r '.number')
+          ISSUE_NODE=$(echo "$ISSUE_JSON" | jq -r '.node_id')
+          echo "Created issue #$ISSUE_NUM (node=$ISSUE_NODE)"
 
-          echo "Created issue #$ISSUE_NUM"
+          OWNER="${REPO%/*}"
+          NAME="${REPO#*/}"
+          COPILOT_ID=$(gh api graphql \
+            -f query='query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ suggestedActors(capabilities:[CAN_BE_ASSIGNED], first:50){ nodes { __typename ... on Bot { login id } ... on User { login id } } } } }' \
+            -f owner="$OWNER" -f name="$NAME" \
+            --jq '[.data.repository.suggestedActors.nodes[] | select(.login=="copilot-swe-agent" or .login=="Copilot")] | .[0].id // empty')
+
+          if [ -z "$COPILOT_ID" ]; then
+            echo "::error::Copilot not found in suggestedActors. ADMIN_GITHUB_TOKEN must belong to a user with a Copilot seat in this org."
+            gh issue comment "$ISSUE_NUM" --repo "$REPO" --body "Auto-assignment failed: Copilot not visible to ADMIN_GITHUB_TOKEN. Please assign Copilot manually." || true
+            exit 1
+          fi
+
+          gh api graphql \
+            -f query='mutation($a:ID!,$b:[ID!]!){ replaceActorsForAssignable(input:{assignableId:$a, actorIds:$b}){ assignable { ... on Issue { number assignees(first:5){ nodes { login } } } } } }' \
+            -f a="$ISSUE_NODE" -f b="$COPILOT_ID"
+
           echo "issue_number=$ISSUE_NUM" >> "$GITHUB_OUTPUT"
 
   wait-and-merge:


### PR DESCRIPTION
## Why

The Sync from Docs workflow has been failing with HTTP 422 every time Docs pushes:

- The issue-creation request used `agent_assignment` (not a valid Issues REST field).
- It also tried to assign `copilot-swe-agent[bot]` (not a valid assignee login).

GitHub silently swallows invalid bot assignees on the REST endpoint, but the bogus `agent_assignment` field triggers a hard 422.

## What

- Drop `agent_assignment` from the create-issue payload.
- Drop the invalid assignee from the create-issue payload.
- After creating the issue, look up Copilot's id via GraphQL `suggestedActors(capabilities: [CAN_BE_ASSIGNED])`, then assign via `replaceActorsForAssignable`.
- Use `ADMIN_GITHUB_TOKEN` (must belong to a user with a Copilot seat) for assignment.

## Verification

A local dry run with the admin token successfully:
- found Copilot in `suggestedActors` (login `copilot-swe-agent`),
- assigned it via the mutation,
- and the timeline emitted a `Copilot connected` event indicating the agent session started.

Closes the regression that has blocked auto-sync since April.