### PR TITLE
feat(seedance): add Seedance Video Generation API docs + sync mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Monorepo for all AceDataCloud API documentation repositories.
 | `openai/` | [OpenAIAPI](https://github.com/AceDataCloud/OpenAIAPI) | OpenAI-compatible API docs |
 | `pixverse/` | [PixverseAPI](https://github.com/AceDataCloud/PixverseAPI) | Pixverse video generation API docs |
 | `wan/` | [WanAPI](https://github.com/AceDataCloud/WanAPI) | Wan (Tongyi Wanxiang) video generation API docs |
+| `seedance/` | [SeedanceAPI](https://github.com/AceDataCloud/SeedanceAPI) | Seedance (ByteDance) video generation API docs |
 | `aichat/` | — | AI Dialogue (multi-model chat) API docs |
 
 ## MCP Servers

--- a/seedance/README.md
+++ b/seedance/README.md
@@ -1,0 +1,84 @@
+# Seedance Video Generation API
+
+ByteDance Seedance AI video generation service with text, image, audio, and video multimodal input.
+
+![Platform](https://img.shields.io/badge/platform-Ace%20Data%20Cloud-0f766e?style=flat-square) ![API](https://img.shields.io/badge/type-AI%20API-2563eb?style=flat-square) ![Docs](https://img.shields.io/badge/docs-online-16a34a?style=flat-square)
+
+API home page: [Ace Data Cloud - Seedance Video Generation](https://platform.acedata.cloud/service/seedance)
+
+Keywords: seedance-api, ai-video, video-generation, bytedance, doubao, text-to-video, image-to-video, reference-audio, reference-video, real-person-reference, rest-api, ai-api, aivideo, AI API, REST API, Developer API, Ace Data Cloud
+
+## Why Use Seedance Video Generation on Ace Data Cloud
+
+- Unified developer platform with one API key, billing system, and usage tracking
+- Production-ready AI API endpoints served from [https://api.acedata.cloud](https://api.acedata.cloud)
+- English integration guides, API references, and service documentation
+- Global-ready workflow for developers building chat, image, video, music, and search products
+
+## Overview
+
+The Seedance Videos Generation API generates official ByteDance Seedance (Doubao) videos by inputting custom parameters such as a `content` array (text, image, audio, video), `model`, `resolution`, `ratio`, and `duration`.
+
+The Seedance 2.0 series (`doubao-seedance-2-0-260128`, `doubao-seedance-2-0-fast-260128`, `doubao-seedance-2-0-mini-260615`) adds multimodal reference inputs: real-person / character image references, reference audio, and reference video.
+
+The Seedance Tasks API queries the execution status of tasks by inputting the task ID returned by the Seedance Videos Generation API.
+
+## Application Process
+
+To use the Seedance Videos Generation API, apply for the corresponding service on the [Seedance Videos Generation API](https://platform.acedata.cloud/documents/0083b874-4da6-40df-87e3-835b1300c1e8) page. After entering the page, click the "Acquire" button.
+
+There is a free quota available for first-time applicants, allowing you to use this API for free.
+
+## Quick Start
+
+- Base URL: [https://api.acedata.cloud](https://api.acedata.cloud)
+- Service page: [Seedance Video Generation on Ace Data Cloud](https://platform.acedata.cloud/service/seedance)
+- Docs: [Developer documentation](https://docs.acedata.cloud)
+
+```bash
+curl --request POST "https://api.acedata.cloud/seedance/videos" \
+  --header "Authorization: Bearer YOUR_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "model": "doubao-seedance-2-0-260128",
+    "content": [
+      { "type": "text", "text": "A dancer performing contemporary ballet in a misty forest" }
+    ],
+    "resolution": "1080p",
+    "ratio": "16:9",
+    "duration": 5
+  }'
+```
+
+## Models
+
+| Model | Generation | Notes |
+| ---- | ---- | ---- |
+| `doubao-seedance-2-0-260128` | 2.0 | Latest generation, highest quality, multimodal reference, up to 4k (recommended) |
+| `doubao-seedance-2-0-fast-260128` | 2.0 Fast | Faster 2.0, up to 720p |
+| `doubao-seedance-2-0-mini-260615` | 2.0 Mini | Lightweight / most cost-effective 2.0, up to 720p |
+| `doubao-seedance-1-5-pro-251215` | 1.5 Pro | Supports audio generation |
+| `doubao-seedance-1-0-pro-250528` | 1.0 Pro | Standard quality |
+| `doubao-seedance-1-0-pro-fast-251015` | 1.0 Fast | Faster generation |
+| `doubao-seedance-1-0-lite-t2v-250428` | 1.0 Lite T2V | Lightweight text-to-video |
+| `doubao-seedance-1-0-lite-i2v-250428` | 1.0 Lite I2V | Lightweight image-to-video |
+
+## APIs and Guides
+
+Explore the supported endpoints and integration guides for Seedance Video Generation.
+
+| API | Path | Integration Guidance |
+| ---- | ---- | ------------ |
+| [Seedance Videos Generation API](https://platform.acedata.cloud/documents/0083b874-4da6-40df-87e3-835b1300c1e8) | `/seedance/videos` | [Seedance Videos Generation API Integration Guide](docs/seedance_videos_generation_api_integration_guide.md) |
+| [Seedance Tasks API](https://platform.acedata.cloud/documents/c09d6a1b-3cca-4f7c-add3-8c14be60da3c) | `/seedance/tasks` | [Seedance Tasks API Integration Guide](docs/seedance_tasks_api_integration_guide.md) |
+
+## Related Resources
+
+- [Ace Data Cloud Developer Platform](https://platform.acedata.cloud)
+- [Ace Data Cloud Docs](https://docs.acedata.cloud)
+- [Status Page](https://status.acedata.cloud)
+- [Ace Data Cloud GitHub Organization](https://github.com/AceDataCloud)
+
+## Support
+
+If you meet any issue, please check [support info](https://platform.acedata.cloud/support) or browse the latest documentation on [docs.acedata.cloud](https://docs.acedata.cloud)

--- a/seedance/docs/seedance_tasks_api_integration_guide.md
+++ b/seedance/docs/seedance_tasks_api_integration_guide.md
@@ -1,0 +1,115 @@
+# Seedance Tasks API Integration and Usage
+
+The main function of the Seedance Tasks API is to query the execution status of tasks by inputting the task ID returned by the Seedance Videos Generation API.
+
+This document describes the Seedance Tasks API integration, helping you query the status and final result of an asynchronous Seedance video generation task.
+
+## Application Process
+
+To use the Seedance Tasks API, you first need to apply for the corresponding service on the application page [Seedance Videos Generation API](https://platform.acedata.cloud/documents/0083b874-4da6-40df-87e3-835b1300c1e8), and then copy the task ID returned by the Seedance Videos Generation API.
+
+Finally, go to the Tasks API page [Seedance Tasks API](https://platform.acedata.cloud/documents/c09d6a1b-3cca-4f7c-add3-8c14be60da3c) to apply for the corresponding service. After entering the page, click the "Acquire" button.
+
+If you are not logged in or registered, you will be automatically redirected to the [login page](https://platform.acedata.cloud) inviting you to register and log in. After logging in or registering, you will be automatically returned to the current page.
+
+There is a free quota available for first-time applicants, allowing you to use this API for free.
+
+## Request Example
+
+The Seedance Tasks API queries the result of a task created by the Seedance Videos Generation API. For how to create a task, see [Seedance Videos Generation API](https://platform.acedata.cloud/documents/0083b874-4da6-40df-87e3-835b1300c1e8) and submit the request with `"async": true` (or a `callback_url`).
+
+We will take a task ID returned by the Seedance Videos Generation API as an example. Suppose the task ID is `ec22ae22-0140-4033-8c86-a48b536da595`.
+
+### Setting Request Headers and Request Body
+
+**Request Headers** include:
+
+- `accept`: Specifies that the response should be in JSON format, set to `application/json`.
+- `authorization`: The key to call the API, which can be selected directly after application.
+
+**Request Body** includes:
+
+- `id`: The task ID returned by the Seedance Videos Generation API.
+
+### Code Example
+
+#### CURL
+
+```bash
+curl -X POST 'https://api.acedata.cloud/seedance/tasks' \
+  -H 'accept: application/json' \
+  -H 'authorization: Bearer {token}' \
+  -H 'content-type: application/json' \
+  -d '{
+    "id": "ec22ae22-0140-4033-8c86-a48b536da595"
+  }'
+```
+
+#### Python
+
+```python
+import requests
+
+url = "https://api.acedata.cloud/seedance/tasks"
+headers = {
+    "accept": "application/json",
+    "authorization": "Bearer {token}",
+    "content-type": "application/json",
+}
+payload = {"id": "ec22ae22-0140-4033-8c86-a48b536da595"}
+
+response = requests.post(url, json=payload, headers=headers)
+print(response.json())
+```
+
+### Response Example
+
+While the task is still running, the `status` will not yet be `succeeded`:
+
+```json
+{
+  "success": true,
+  "task_id": "ec22ae22-0140-4033-8c86-a48b536da595",
+  "trace_id": "1cc87db0-8ee5-4436-969b-35cc571a9fd5",
+  "data": {
+    "task_id": "cgt-20251222005129-62fhb",
+    "status": "processing"
+  }
+}
+```
+
+When the task has completed, the response includes the final `video_url`:
+
+```json
+{
+  "success": true,
+  "task_id": "ec22ae22-0140-4033-8c86-a48b536da595",
+  "trace_id": "1cc87db0-8ee5-4436-969b-35cc571a9fd5",
+  "data": {
+    "task_id": "cgt-20251222005129-62fhb",
+    "status": "succeeded",
+    "video_url": "https://platform.cdn.acedata.cloud/seedance/f592800a-b87c-4705-8796-cbb8018cae35.mp4",
+    "model": "doubao-seedance-2-0-260128"
+  }
+}
+```
+
+The returned result contains the following fields:
+
+- `success`: whether the query succeeded.
+- `task_id`: the ID of the video generation task.
+- `trace_id`: the trace ID for this request.
+- `data`: the task result, including `status` and — once the task is `succeeded` — the `video_url` and `model`.
+
+Poll this endpoint until `data.status` is `succeeded` (or a terminal failure state), then download the video from `data.video_url`.
+
+## Error Codes
+
+| HTTP Status | Code | Meaning |
+| ---- | ---- | ---- |
+| 400 | `bad_request` | Invalid request, e.g. a missing or malformed task `id`. |
+| 401 | `invalid_token` | The token is invalid or wrong. |
+| 401 | `token_expired` | The token has expired. |
+| 404 | `not_found` | The specified task ID was not found. |
+
+Each error response includes a `trace_id` to help with debugging and support.

--- a/seedance/docs/seedance_videos_generation_api_integration_guide.md
+++ b/seedance/docs/seedance_videos_generation_api_integration_guide.md
@@ -1,0 +1,159 @@
+# Seedance Videos Generation API Integration Instructions
+
+This article introduces the Seedance Videos Generation API integration instructions, which can generate official ByteDance Seedance (Doubao) videos by inputting custom parameters such as a multimodal `content` array, model, resolution, aspect ratio, and duration.
+
+## Application Process
+
+To use the Seedance Videos Generation API, apply for the corresponding service on the [Seedance Videos Generation API](https://platform.acedata.cloud/documents/0083b874-4da6-40df-87e3-835b1300c1e8) page. After entering the page, click the "Acquire" button.
+
+If you are not logged in or registered, you will be automatically redirected to the login page inviting you to register and log in. After logging in or registering, you will be automatically returned to the current page.
+
+There is a free quota available for first-time applicants, allowing you to use this API for free. **One API key can call every service on the platform — you do not need to apply separately for each service.**
+
+## Basic Usage
+
+The most basic usage is to input a `content` array containing a single text item plus a `model`. The result is the generated video. The request body fields are described below:
+
+- `model`: the model used to generate the video. Available values:
+  - **Seedance 2.0 series** (multimodal reference: real-person / character image, reference audio, reference video): `doubao-seedance-2-0-260128` (standard), `doubao-seedance-2-0-fast-260128` (fast), `doubao-seedance-2-0-mini-260615` (lightweight).
+  - **Seedance 1.x**: `doubao-seedance-1-5-pro-251215`, `doubao-seedance-1-0-pro-250528`, `doubao-seedance-1-0-pro-fast-251015`, `doubao-seedance-1-0-lite-t2v-250428`, `doubao-seedance-1-0-lite-i2v-250428`.
+- `content`: the input array. Each item carries a `type` of `text`, `image_url`, `audio_url`, or `video_url`:
+  - `text`: `{ "type": "text", "text": "..." }` — the prompt (max 1000 characters).
+  - `image_url`: `{ "type": "image_url", "role": "first_frame|last_frame|reference_image", "image_url": { "url": "https://..." } }`.
+  - `audio_url` (Seedance 2.0): `{ "type": "audio_url", "audio_url": { "url": "https://..." } }` — reference audio for voice timbre / background music.
+  - `video_url` (Seedance 2.0): `{ "type": "video_url", "video_url": { "url": "https://..." } }` — reference video for subject, camera movement, motion or overall style.
+- `resolution`: output resolution, one of `480p`, `720p`, `1080p`, `4k`. `4k` is supported only by `doubao-seedance-2-0-260128`; `doubao-seedance-2-0-fast-260128` and `doubao-seedance-2-0-mini-260615` cap at `720p`. If omitted, a default resolution is selected based on the chosen model.
+- `ratio`: aspect ratio, one of `16:9`, `4:3`, `1:1`, `3:4`, `9:16`, `21:9`, `adaptive`. Default `16:9`.
+- `duration`: video duration in seconds, `2`–`15` (the Seedance 2.0 series supports `4`–`15`).
+- `frames`: frame count, `29`–`361` (must satisfy 25+4n). Mutually exclusive with `duration`.
+- `seed`: random seed, integer `-1`–`4294967295` (`-1` = random).
+- `camerafixed`: whether to fix the camera position, `true` / `false`.
+- `watermark`: whether to add a watermark, `true` / `false`.
+- `generate_audio`: whether to generate audio. Supported by `doubao-seedance-1-5-pro-251215` and the `doubao-seedance-2-0` series; other models ignore it. Default `false`.
+- `callback_url`: an asynchronous callback URL. When provided, the API returns immediately with a `task_id` and POSTs the result to this URL when generation completes.
+- `async`: optional. When `true`, the API returns immediately with a `task_id` (no `callback_url` required); poll the result with the Seedance Tasks API.
+
+### Request Example
+
+```bash
+curl -X POST 'https://api.acedata.cloud/seedance/videos' \
+  -H 'accept: application/json' \
+  -H 'authorization: Bearer {token}' \
+  -H 'content-type: application/json' \
+  -d '{
+    "model": "doubao-seedance-2-0-260128",
+    "content": [
+      { "type": "text", "text": "A street dancer doing breakdancing moves in an urban setting" }
+    ],
+    "resolution": "1080p",
+    "ratio": "16:9",
+    "duration": 5
+  }'
+```
+
+### Response Example
+
+```json
+{
+  "success": true,
+  "task_id": "ec22ae22-0140-4033-8c86-a48b536da595",
+  "trace_id": "1cc87db0-8ee5-4436-969b-35cc571a9fd5",
+  "data": {
+    "task_id": "cgt-20251222005129-62fhb",
+    "status": "succeeded",
+    "video_url": "https://platform.cdn.acedata.cloud/seedance/f592800a-b87c-4705-8796-cbb8018cae35.mp4",
+    "model": "doubao-seedance-2-0-260128"
+  }
+}
+```
+
+The returned result contains the following fields:
+
+- `success`: the status of the video generation task.
+- `task_id`: the ID of the video generation task.
+- `trace_id`: the trace ID for this request.
+- `data`: the result of the video generation task, including `status`, `video_url`, and `model`.
+
+Download the generated video from the `video_url` field.
+
+## Workflows
+
+### Text-to-Video
+
+Pass a single `text` item in the `content` array (see the request example above).
+
+### Image-to-Video
+
+Add an `image_url` item with a `role`:
+
+```json
+{
+  "model": "doubao-seedance-2-0-260128",
+  "content": [
+    { "type": "text", "text": "the person starts dancing gracefully" },
+    { "type": "image_url", "role": "first_frame", "image_url": { "url": "https://example.com/dancer.jpg" } }
+  ],
+  "resolution": "720p",
+  "duration": 5
+}
+```
+
+Image roles:
+
+- `first_frame` — the image is used as the opening frame.
+- `last_frame` — the image is used as the closing frame.
+- `reference_image` — the image is used as a style / subject / real-person reference.
+
+`first_frame` and `last_frame` may be combined in a single request, but `reference_image` is mutually exclusive with `first_frame` / `last_frame`.
+
+### Real-Person / Character Reference (Seedance 2.0)
+
+The Seedance 2.0 series can keep a specific person or character consistent across a brand-new scene. Pass one or more photos as `image_url` items with `role: "reference_image"` (up to 9):
+
+```json
+{
+  "model": "doubao-seedance-2-0-260128",
+  "content": [
+    { "type": "text", "text": "the same person walking through a neon-lit night market, cinematic" },
+    { "type": "image_url", "role": "reference_image", "image_url": { "url": "https://example.com/person.jpg" } }
+  ],
+  "resolution": "1080p",
+  "duration": 8
+}
+```
+
+### Reference Audio / Video (Seedance 2.0)
+
+The Seedance 2.0 series also accepts reference audio (voice timbre, background music) and reference video (subject, camera movement, motion, overall style). Limits: up to 3 audio and 3 video references.
+
+```json
+{
+  "model": "doubao-seedance-2-0-260128",
+  "content": [
+    { "type": "text", "text": "a singer performing on stage, matching the reference voice and motion" },
+    { "type": "image_url", "role": "reference_image", "image_url": { "url": "https://example.com/person.jpg" } },
+    { "type": "audio_url", "audio_url": { "url": "https://example.com/voice.mp3" } },
+    { "type": "video_url", "video_url": { "url": "https://example.com/motion.mp4" } }
+  ],
+  "generate_audio": true
+}
+```
+
+## Asynchronous Generation
+
+Video generation can take time. To avoid long-held HTTP connections, use one of the asynchronous modes:
+
+- **Callback**: set `callback_url`. The API returns immediately with a `task_id` and POSTs the final result to your URL when generation completes.
+- **Polling**: set `"async": true`. The API returns immediately with a `task_id`; poll the result with the [Seedance Tasks API](https://platform.acedata.cloud/documents/c09d6a1b-3cca-4f7c-add3-8c14be60da3c).
+
+## Error Codes
+
+| HTTP Status | Code | Meaning |
+| ---- | ---- | ---- |
+| 400 | `bad_request` | Invalid request, e.g. an invalid `model`. |
+| 401 | `invalid_token` | The token is invalid or wrong. |
+| 401 | `token_expired` | The token has expired. |
+| 400 | `no_token` | No token was specified for the request. |
+| 500 | `internal_error` | An internal or upstream error occurred. |
+
+Each error response includes a `trace_id` to help with debugging and support.

--- a/sync.yaml
+++ b/sync.yaml
@@ -49,3 +49,8 @@ mappings:
     exclude:
       - .github
       - .gitbooks
+  seedance:
+    repo: AceDataCloud/SeedanceAPI
+    exclude:
+      - .github
+      - .gitbooks


### PR DESCRIPTION
The `APIs` monorepo had no `seedance/` folder at all (Seedance was missing from both the docs tree and `sync.yaml`), even though Seedance is a live, GA service. This adds the English integration-guide docs and wires up the mirror repo.

## What's added
- `seedance/README.md` — service overview, model table (2.0 series incl. mini + 1.x), quick start, API/guide index.
- `seedance/docs/seedance_videos_generation_api_integration_guide.md` — full `/seedance/videos` guide: multimodal `content` (text/image_url/audio_url/video_url), roles, resolution incl. `4k`, duration `2–15`, real-person/character reference, reference audio/video, async modes, error codes.
- `seedance/docs/seedance_tasks_api_integration_guide.md` — `/seedance/tasks` polling guide.
- `README.md` table row + `sync.yaml` mapping → `AceDataCloud/SeedanceAPI` (the mirror repo was created so the post-merge `sync-to-repos` run won't 404).

Content is derived from the live Seedance 2.0 spec (PlatformBackend OpenAPI `0083b874-…`, cost rules, and the ephone worker).

## 🤖 对抗评审

Reviewer: **Codex** (`codex exec --sandbox read-only`, cross-model). One round. Codex could not fetch our platform OpenAPI from its sandbox, so several flags were rebutted against the spec I read directly.

- RISK: `2-0-260128` marked "(default)". → **Fixed**: the videos API requires `model` (no server default); softened to "(recommended)".
- RISK: resolution default "720p most / 480p lite". → **Fixed**: that was stale 1.x text; the worker defaults by model — reworded to "a default resolution is selected based on the chosen model".
- RISK: duration "4–15" vs "2–15". → **Rebut**: the schema accepts 2–15; the worker comment states 2.0 prefers 4–15. Text reads "2–15 (the Seedance 2.0 series supports 4–15)".
- RISK: `frames`/`seed`/`camerafixed`/`watermark`/`callback_url`/`async` unsupported. → **Rebut**: all are in the OpenAPI request schema; `callback_url`/`async` are the platform-standard async mechanism (documented across all services).
- RISK: `generate_audio` "ignore it" / default false. → **Rebut**: both come directly from the OpenAPI (`"default": false`; i18n "其他模型将忽略该参数").
- RISK: `reference_image` exclusivity with first/last. → **Rebut**: the worker explicitly enforces `cannot mix reference_image with first_frame/last_frame`.
- RISK: error-code tables unsupported. → **Rebut**: the videos codes (bad_request/invalid_token/token_expired/no_token) match the OpenAPI's documented 400/401/500 responses.

VERDICT after fixes: CLEAN.
