### PR TITLE
chore(seedance): drop dead 1.x models (2.0-only)

### DIFF
--- a/seedance/README.md
+++ b/seedance/README.md
@@ -57,11 +57,6 @@ curl --request POST "https://api.acedata.cloud/seedance/videos" \
 | `doubao-seedance-2-0-260128` | 2.0 | Latest generation, highest quality, multimodal reference, up to 4k (recommended) |
 | `doubao-seedance-2-0-fast-260128` | 2.0 Fast | Faster 2.0, up to 720p |
 | `doubao-seedance-2-0-mini-260615` | 2.0 Mini | Lightweight / most cost-effective 2.0, up to 720p |
-| `doubao-seedance-1-5-pro-251215` | 1.5 Pro | Supports audio generation |
-| `doubao-seedance-1-0-pro-250528` | 1.0 Pro | Standard quality |
-| `doubao-seedance-1-0-pro-fast-251015` | 1.0 Fast | Faster generation |
-| `doubao-seedance-1-0-lite-t2v-250428` | 1.0 Lite T2V | Lightweight text-to-video |
-| `doubao-seedance-1-0-lite-i2v-250428` | 1.0 Lite I2V | Lightweight image-to-video |
 
 ## APIs and Guides
 

--- a/seedance/docs/seedance_videos_generation_api_integration_guide.md
+++ b/seedance/docs/seedance_videos_generation_api_integration_guide.md
@@ -16,7 +16,6 @@ The most basic usage is to input a `content` array containing a single text item
 
 - `model`: the model used to generate the video. Available values:
   - **Seedance 2.0 series** (multimodal reference: real-person / character image, reference audio, reference video): `doubao-seedance-2-0-260128` (standard), `doubao-seedance-2-0-fast-260128` (fast), `doubao-seedance-2-0-mini-260615` (lightweight).
-  - **Seedance 1.x**: `doubao-seedance-1-5-pro-251215`, `doubao-seedance-1-0-pro-250528`, `doubao-seedance-1-0-pro-fast-251015`, `doubao-seedance-1-0-lite-t2v-250428`, `doubao-seedance-1-0-lite-i2v-250428`.
 - `content`: the input array. Each item carries a `type` of `text`, `image_url`, `audio_url`, or `video_url`:
   - `text`: `{ "type": "text", "text": "..." }` — the prompt (max 1000 characters).
   - `image_url`: `{ "type": "image_url", "role": "first_frame|last_frame|reference_image", "image_url": { "url": "https://..." } }`.
@@ -29,7 +28,6 @@ The most basic usage is to input a `content` array containing a single text item
 - `seed`: random seed, integer `-1`–`4294967295` (`-1` = random).
 - `camerafixed`: whether to fix the camera position, `true` / `false`.
 - `watermark`: whether to add a watermark, `true` / `false`.
-- `generate_audio`: whether to generate audio. Supported by `doubao-seedance-1-5-pro-251215` and the `doubao-seedance-2-0` series; other models ignore it. Default `false`.
 - `callback_url`: an asynchronous callback URL. When provided, the API returns immediately with a `task_id` and POSTs the result to this URL when generation completes.
 - `async`: optional. When `true`, the API returns immediately with a `task_id` (no `callback_url` required); poll the result with the Seedance Tasks API.
 


### PR DESCRIPTION
Follow-up: live worker rejects Seedance 1.x; remove them from the advertised model lists/docs to match the OpenAPI which is now 2.0-only. Bot + 2.0 tests pass.