### PR TITLE
docs: add API guides for producer, fish, face, shorturl

### DIFF
--- a/face/README.md
+++ b/face/README.md
@@ -1,0 +1,65 @@
+# Face Transformation API
+
+Face analysis and transformation service: detect keypoints, beautify portraits, change age/gender, swap faces, cartoonify, and detect liveness.
+
+![Platform](https://img.shields.io/badge/platform-Ace%20Data%20Cloud-0f766e?style=flat-square) ![API](https://img.shields.io/badge/type-AI%20API-2563eb?style=flat-square) ![Docs](https://img.shields.io/badge/docs-online-16a34a?style=flat-square)
+
+API home page: [Ace Data Cloud - Face Transformation](https://platform.acedata.cloud/service/face-change)
+
+Keywords: face-api, face-swap, face-detection, beautify, face-cartoon, age-change, gender-change, liveness, image-api, ai-api, AI API, REST API, Developer API, Ace Data Cloud
+
+## Why Use Face Transformation on Ace Data Cloud
+
+- Unified developer platform with one API key, billing system, and usage tracking
+- Production-ready AI API endpoints served from [https://api.acedata.cloud](https://api.acedata.cloud)
+- English integration guides, API references, and service documentation
+- Global-ready workflow for developers building chat, image, video, music, and search products
+
+## Overview
+
+The Face Transformation service provides seven endpoints for analyzing and editing faces in photos: keypoint analysis, beautification, age/gender transformation, face swap, cartoon avatars, and liveness detection.
+
+## Application Process
+
+To use the Face Transformation APIs, apply for the corresponding service on the [Face Swap API](https://platform.acedata.cloud/documents/6be9e2dd-e3ca-4e8f-b38c-d5057e92354e) page. After entering the page, click the "Acquire" button.
+
+There is a free quota available for first-time applicants, allowing you to use this API for free.
+
+## Quick Start
+
+- Base URL: [https://api.acedata.cloud](https://api.acedata.cloud)
+- Service page: [Face Transformation on Ace Data Cloud](https://platform.acedata.cloud/service/face-change)
+- Docs: [Developer documentation](https://docs.acedata.cloud)
+
+```bash
+curl --request POST "https://api.acedata.cloud/face/swap" \
+  --header "Authorization: Bearer YOUR_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "source_image_url": "https://example.com/source.jpg",
+    "target_image_url": "https://example.com/target.jpg"
+  }'
+```
+
+## APIs and Guides
+
+| API | Path | Integration Guidance |
+| ---- | ---- | ------------ |
+| [Face Swap API](https://platform.acedata.cloud/documents/6be9e2dd-e3ca-4e8f-b38c-d5057e92354e) | `/face/swap` | [Face Swap API Integration Guide](docs/face_swap_api_integration_guide.md) |
+| [Face Beautify API](https://platform.acedata.cloud/documents/7d536eb6-8fea-48d5-a050-43aa57a23f7e) | `/face/beautify` | [Face Beautify API Integration Guide](docs/face_beautify_api_integration_guide.md) |
+| [Face Analyze API](https://platform.acedata.cloud/documents/e4fbc3b6-4f44-48fb-a049-40f5c27c7cd3) | `/face/analyze` | Detect face keypoints and shape |
+| [Face ChangeAge API](https://platform.acedata.cloud/documents/2c7f6468-58d9-4611-885b-1e34664d49e9) | `/face/change-age` | Age a face up or down |
+| [Face ChangeGender API](https://platform.acedata.cloud/documents/2f64e798-d272-460d-92c5-9c1ff99f223b) | `/face/change-gender` | Swap perceived gender |
+| [Face Cartoon API](https://platform.acedata.cloud/documents/1bbce3f9-beec-46bd-8423-5642f0c9e3b8) | `/face/cartoon` | Cartoonify a portrait |
+| [Face DetectLive API](https://platform.acedata.cloud/documents/96006810-b5b7-4585-90eb-90c2ca127b67) | `/face/detect-live` | Liveness detection |
+
+## Related Resources
+
+- [Ace Data Cloud Developer Platform](https://platform.acedata.cloud)
+- [Ace Data Cloud Docs](https://docs.acedata.cloud)
+- [Status Page](https://status.acedata.cloud)
+- [Ace Data Cloud GitHub Organization](https://github.com/AceDataCloud)
+
+## Support
+
+If you meet any issue, please check [support info](https://platform.acedata.cloud/support) or browse the latest documentation on [docs.acedata.cloud](https://docs.acedata.cloud)

--- a/face/docs/face_beautify_api_integration_guide.md
+++ b/face/docs/face_beautify_api_integration_guide.md
@@ -1,0 +1,49 @@
+# Face Beautify API Integration Instructions
+
+This article introduces the Face Beautify API integration instructions, which enhances a portrait with adjustable smoothing, whitening, face-lifting, and eye-enlarging controls.
+
+## Application Process
+
+To use the Face Beautify API, apply for the corresponding service on the [Face Beautify API](https://platform.acedata.cloud/documents/7d536eb6-8fea-48d5-a050-43aa57a23f7e) page. After entering the page, click the "Acquire" button.
+
+If you are not logged in or registered, you will be automatically redirected to the login page inviting you to register and log in. After logging in or registering, you will be automatically returned to the current page.
+
+There is a free quota available for first-time applicants, allowing you to use this API for free. **One API key can call every service on the platform — you do not need to apply separately for each service.**
+
+## Basic Usage
+
+The most basic usage is to provide an `image_url`. The result is the beautified image. The request body fields are described below:
+
+- `image_url`: the portrait to beautify (required).
+- `smoothing`: skin smoothing strength.
+- `whitening`: skin whitening strength.
+- `face_lifting`: face slimming strength.
+- `eye_enlarging`: eye enlargement strength.
+
+### Request Example
+
+```bash
+curl -X POST 'https://api.acedata.cloud/face/beautify' \
+  -H 'accept: application/json' \
+  -H 'authorization: Bearer {token}' \
+  -H 'content-type: application/json' \
+  -d '{
+    "image_url": "https://example.com/portrait.jpg",
+    "smoothing": 5,
+    "whitening": 5
+  }'
+```
+
+### Response Example
+
+```json
+{
+  "image_url": "https://faceeffect-1254418846.cos.ap-guangzhou.myqcloud.com/fmu/BeautifyPic/1256437459/4027c868-60e9-40e0-b929-0fdb69dcf3c1"
+}
+```
+
+Download the beautified image from the `image_url` field.
+
+## Support
+
+If you meet any issue, please check [support info](https://platform.acedata.cloud/support) or browse the latest documentation on [docs.acedata.cloud](https://docs.acedata.cloud)

--- a/face/docs/face_swap_api_integration_guide.md
+++ b/face/docs/face_swap_api_integration_guide.md
@@ -1,0 +1,48 @@
+# Face Swap API Integration Instructions
+
+This article introduces the Face Swap API integration instructions, which replaces the face in a target image with the face from a source image.
+
+## Application Process
+
+To use the Face Swap API, apply for the corresponding service on the [Face Swap API](https://platform.acedata.cloud/documents/6be9e2dd-e3ca-4e8f-b38c-d5057e92354e) page. After entering the page, click the "Acquire" button.
+
+If you are not logged in or registered, you will be automatically redirected to the login page inviting you to register and log in. After logging in or registering, you will be automatically returned to the current page.
+
+There is a free quota available for first-time applicants, allowing you to use this API for free. **One API key can call every service on the platform — you do not need to apply separately for each service.**
+
+## Basic Usage
+
+The most basic usage is to provide `source_image_url` and `target_image_url`. The result is the merged image. The request body fields are described below:
+
+- `source_image_url`: the photo whose face is taken (required).
+- `target_image_url`: the photo whose face is replaced (required).
+- `timeout`: optional processing timeout in seconds.
+- `callback_url`: an asynchronous callback URL.
+- `async`: optional. When `true`, the API returns immediately with a `task_id`.
+
+### Request Example
+
+```bash
+curl -X POST 'https://api.acedata.cloud/face/swap' \
+  -H 'accept: application/json' \
+  -H 'authorization: Bearer {token}' \
+  -H 'content-type: application/json' \
+  -d '{
+    "source_image_url": "https://example.com/source.jpg",
+    "target_image_url": "https://example.com/target.jpg"
+  }'
+```
+
+### Response Example
+
+```json
+{
+  "image_url": "https://platform.cdn.acedata.cloud/face/swap-result.jpg"
+}
+```
+
+Download the swapped image from the `image_url` field.
+
+## Support
+
+If you meet any issue, please check [support info](https://platform.acedata.cloud/support) or browse the latest documentation on [docs.acedata.cloud](https://docs.acedata.cloud)

--- a/fish/README.md
+++ b/fish/README.md
@@ -1,0 +1,62 @@
+# Fish Voice Generation API
+
+Fish Audio text-to-speech and voice-cloning service: synthesize speech from text and create custom voice models from reference audio.
+
+![Platform](https://img.shields.io/badge/platform-Ace%20Data%20Cloud-0f766e?style=flat-square) ![API](https://img.shields.io/badge/type-AI%20API-2563eb?style=flat-square) ![Docs](https://img.shields.io/badge/docs-online-16a34a?style=flat-square)
+
+API home page: [Ace Data Cloud - Fish Voice Generation](https://platform.acedata.cloud/service/fish)
+
+Keywords: fish-api, fish-audio, text-to-speech, tts, voice-clone, voice-model, speech-synthesis, rest-api, ai-api, AI API, REST API, Developer API, Ace Data Cloud
+
+## Why Use Fish Voice Generation on Ace Data Cloud
+
+- Unified developer platform with one API key, billing system, and usage tracking
+- Production-ready AI API endpoints served from [https://api.acedata.cloud](https://api.acedata.cloud)
+- English integration guides, API references, and service documentation
+- Global-ready workflow for developers building chat, image, video, music, and search products
+
+## Overview
+
+The Fish TTS API converts text into natural speech, optionally using a cloned voice model. The Fish Model APIs create, query, and fetch custom voice models from reference audio, and the Fish Tasks API polls asynchronous jobs.
+
+## Application Process
+
+To use the Fish TTS API, apply for the corresponding service on the [Fish TTS API](https://platform.acedata.cloud/documents/77adcb84-d59f-5ef9-b8a0-8b35eb42a71d) page. After entering the page, click the "Acquire" button.
+
+There is a free quota available for first-time applicants, allowing you to use this API for free.
+
+## Quick Start
+
+- Base URL: [https://api.acedata.cloud](https://api.acedata.cloud)
+- Service page: [Fish Voice Generation on Ace Data Cloud](https://platform.acedata.cloud/service/fish)
+- Docs: [Developer documentation](https://docs.acedata.cloud)
+
+```bash
+curl --request POST "https://api.acedata.cloud/fish/tts" \
+  --header "Authorization: Bearer YOUR_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "text": "Hello, this is a demonstration of AI voice synthesis."
+  }'
+```
+
+## APIs and Guides
+
+| API | Path | Integration Guidance |
+| ---- | ---- | ------------ |
+| [Fish TTS API](https://platform.acedata.cloud/documents/77adcb84-d59f-5ef9-b8a0-8b35eb42a71d) | `/fish/tts` | [Fish TTS API Integration Guide](docs/fish_tts_api_integration_guide.md) |
+| [Fish Tasks API](https://platform.acedata.cloud/documents/fc541fac-a941-47fd-b6f7-48d6cb9da523) | `/fish/tasks` | [Fish Tasks API Integration Guide](docs/fish_tasks_api_integration_guide.md) |
+| [Fish Model Create API](https://platform.acedata.cloud/documents/82dcabe9-b1a3-541f-80f1-decb183b920c) | `/fish/model` | Create a custom voice model from reference audio |
+| [Fish Model Query API](https://platform.acedata.cloud/documents/0a2c983b-e20f-5926-a45f-07b61373617d) | `/fish/model` | List voice models |
+| [Fish Model Get API](https://platform.acedata.cloud/documents/70f84537-7c48-57d3-9a21-b2a4f55e8f31) | `/fish/model/{id}` | Fetch a single voice model |
+
+## Related Resources
+
+- [Ace Data Cloud Developer Platform](https://platform.acedata.cloud)
+- [Ace Data Cloud Docs](https://docs.acedata.cloud)
+- [Status Page](https://status.acedata.cloud)
+- [Ace Data Cloud GitHub Organization](https://github.com/AceDataCloud)
+
+## Support
+
+If you meet any issue, please check [support info](https://platform.acedata.cloud/support) or browse the latest documentation on [docs.acedata.cloud](https://docs.acedata.cloud)

--- a/fish/docs/fish_tasks_api_integration_guide.md
+++ b/fish/docs/fish_tasks_api_integration_guide.md
@@ -1,0 +1,67 @@
+# Fish Tasks API Integration and Usage
+
+The main function of the Fish Tasks API is to query the execution status of tasks by inputting the task ID returned by the Fish TTS API.
+
+This document describes the Fish Tasks API integration, helping you query the status and final result of an asynchronous Fish voice generation task.
+
+## Application Process
+
+To use the Fish Tasks API, you first need to apply for the corresponding service on the application page [Fish TTS API](https://platform.acedata.cloud/documents/77adcb84-d59f-5ef9-b8a0-8b35eb42a71d), and then copy the task ID returned by the Fish TTS API.
+
+Finally, go to the Tasks API page [Fish Tasks API](https://platform.acedata.cloud/documents/fc541fac-a941-47fd-b6f7-48d6cb9da523) to apply for the corresponding service. After entering the page, click the "Acquire" button.
+
+There is a free quota available for first-time applicants, allowing you to use this API for free.
+
+## Request Example
+
+The Fish Tasks API queries the result of a task created by the Fish TTS API. Create the task with `"async": true` (or a `callback_url`), then poll with the returned `id`.
+
+### Request Body
+
+- `id`: a single task ID returned by the Fish TTS API.
+- `ids`: optional array to query multiple tasks at once.
+- `action`: optional operation type.
+
+### Code Example
+
+```bash
+curl -X POST 'https://api.acedata.cloud/fish/tasks' \
+  -H 'accept: application/json' \
+  -H 'authorization: Bearer {token}' \
+  -H 'content-type: application/json' \
+  -d '{
+    "id": "8a72ff98-4023-4006-a9f7-4cb2fa04f978"
+  }'
+```
+
+```python
+import requests
+
+url = "https://api.acedata.cloud/fish/tasks"
+headers = {
+    "accept": "application/json",
+    "authorization": "Bearer {token}",
+    "content-type": "application/json",
+}
+payload = {"id": "8a72ff98-4023-4006-a9f7-4cb2fa04f978"}
+
+response = requests.post(url, json=payload, headers=headers)
+print(response.json())
+```
+
+### Response Example
+
+```json
+{
+  "data": {
+    "task_id": "8a72ff98-4023-4006-a9f7-4cb2fa04f978",
+    "status": "succeeded",
+    "audio_url": "https://platform.r2.fish.audio/task/8a72ff9840234006a9f74cb2fa04f978.mp3"
+  },
+  "success": true
+}
+```
+
+## Support
+
+If you meet any issue, please check [support info](https://platform.acedata.cloud/support) or browse the latest documentation on [docs.acedata.cloud](https://docs.acedata.cloud)

--- a/fish/docs/fish_tts_api_integration_guide.md
+++ b/fish/docs/fish_tts_api_integration_guide.md
@@ -1,0 +1,74 @@
+# Fish TTS API Integration Instructions
+
+This article introduces the Fish TTS API integration instructions, which converts text into natural speech and can optionally use a custom cloned voice model.
+
+## Application Process
+
+To use the Fish TTS API, apply for the corresponding service on the [Fish TTS API](https://platform.acedata.cloud/documents/77adcb84-d59f-5ef9-b8a0-8b35eb42a71d) page. After entering the page, click the "Acquire" button.
+
+If you are not logged in or registered, you will be automatically redirected to the login page inviting you to register and log in. After logging in or registering, you will be automatically returned to the current page.
+
+There is a free quota available for first-time applicants, allowing you to use this API for free. **One API key can call every service on the platform — you do not need to apply separately for each service.**
+
+## Basic Usage
+
+The most basic usage is to input `text`. The result is a synthesized audio file. The request body fields are described below:
+
+- `text`: the text to synthesize into speech (required).
+- `reference_id`: the voice model ID to use for the timbre. Create one with the Fish Model Create API.
+- `format`: output audio format, e.g. `mp3`, `wav`, `opus`.
+- `sample_rate`: output sample rate.
+- `mp3_bitrate` / `opus_bitrate`: encoding bitrate.
+- `latency`: latency mode (`normal` / `balanced`).
+- `chunk_length` / `min_chunk_length`: chunk sizing for streaming.
+- `temperature`, `top_p`, `repetition_penalty`, `max_new_tokens`: generation controls.
+- `normalize`: whether to normalize text before synthesis.
+- `prosody`: prosody controls.
+- `references`: inline reference samples.
+- `callback_url`: an asynchronous callback URL.
+- `async`: optional. When `true`, the API returns immediately with a `task_id`; poll the result with the Fish Tasks API.
+
+### Request Example
+
+```bash
+curl -X POST 'https://api.acedata.cloud/fish/tts' \
+  -H 'accept: application/json' \
+  -H 'authorization: Bearer {token}' \
+  -H 'content-type: application/json' \
+  -d '{
+    "text": "The quick brown fox jumps over the lazy dog.",
+    "format": "mp3"
+  }'
+```
+
+### Response Example
+
+```json
+{
+  "audio_url": "https://platform.r2.fish.audio/task/8a72ff9840234006a9f74cb2fa04f978.mp3"
+}
+```
+
+Download the generated audio from the `audio_url` field.
+
+## Workflows
+
+### Synthesize with a Cloned Voice
+
+First create a voice model with the Fish Model Create API (`POST /fish/model`) to obtain a model ID, then pass it as `reference_id`:
+
+```json
+{
+  "text": "Welcome to our platform.",
+  "reference_id": "d7900c21663f485ab63ebdb7e5905036"
+}
+```
+
+## Gotchas
+
+- Pricing is based on the byte count of the generated audio.
+- Voice cloning requires a clear reference audio sample.
+
+## Support
+
+If you meet any issue, please check [support info](https://platform.acedata.cloud/support) or browse the latest documentation on [docs.acedata.cloud](https://docs.acedata.cloud)

--- a/producer/README.md
+++ b/producer/README.md
@@ -1,0 +1,71 @@
+# Producer Music Generation API
+
+AI music generation service supporting songs, lyrics, covers, extensions, stem separation, WAV/MP4 export, and reference-audio uploads.
+
+![Platform](https://img.shields.io/badge/platform-Ace%20Data%20Cloud-0f766e?style=flat-square) ![API](https://img.shields.io/badge/type-AI%20API-2563eb?style=flat-square) ![Docs](https://img.shields.io/badge/docs-online-16a34a?style=flat-square)
+
+API home page: [Ace Data Cloud - Producer Music Generation](https://platform.acedata.cloud/service/producer)
+
+Keywords: producer-api, ai-music, music-generation, song-generation, lyrics, cover, extend, stems, text-to-music, rest-api, ai-api, AI API, REST API, Developer API, Ace Data Cloud
+
+## Why Use Producer Music Generation on Ace Data Cloud
+
+- Unified developer platform with one API key, billing system, and usage tracking
+- Production-ready AI API endpoints served from [https://api.acedata.cloud](https://api.acedata.cloud)
+- English integration guides, API references, and service documentation
+- Global-ready workflow for developers building chat, image, video, music, and search products
+
+## Overview
+
+The Producer Audios Generation API generates AI songs from a text `prompt` or custom `lyric`, with support for instrumental-only tracks, covers, extensions, and section replacement. The Producer Lyrics Generation API drafts lyrics from a prompt. The Producer Wav / Videos APIs export a finished track to WAV audio or MP4 video, the Upload API registers a reference audio for cover/extend, and the Tasks API polls asynchronous jobs.
+
+## Application Process
+
+To use the Producer Audios Generation API, apply for the corresponding service on the [Producer Audios Generation API](https://platform.acedata.cloud/documents/01d96900-9f8c-41d7-814c-95c7a885ba61) page. After entering the page, click the "Acquire" button.
+
+There is a free quota available for first-time applicants, allowing you to use this API for free.
+
+## Quick Start
+
+- Base URL: [https://api.acedata.cloud](https://api.acedata.cloud)
+- Service page: [Producer Music Generation on Ace Data Cloud](https://platform.acedata.cloud/service/producer)
+- Docs: [Developer documentation](https://docs.acedata.cloud)
+
+```bash
+curl --request POST "https://api.acedata.cloud/producer/audios" \
+  --header "Authorization: Bearer YOUR_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "action": "generate",
+    "prompt": "upbeat electronic dance track with synth leads"
+  }'
+```
+
+## Models
+
+| Model | Notes |
+| ---- | ---- |
+| `FUZZ-2.0 Pro` | Default, highest quality |
+| `FUZZ-2.0` | Standard quality |
+| `FUZZ-2.0 Raw` | Raw output variant |
+| `FUZZ-1.1 Pro` | Pro v1.1 |
+| `FUZZ-1.0 Pro` | Pro v1.0 |
+| `FUZZ-1.1` / `FUZZ-1.0` / `FUZZ-0.8` | Earlier versions |
+
+## APIs and Guides
+
+| API | Path | Integration Guidance |
+| ---- | ---- | ------------ |
+| [Producer Audios Generation API](https://platform.acedata.cloud/documents/01d96900-9f8c-41d7-814c-95c7a885ba61) | `/producer/audios` | [Producer Audios Generation API Integration Guide](docs/producer_audios_generation_api_integration_guide.md) |
+| [Producer Tasks API](https://platform.acedata.cloud/documents/e706d672-d7c9-4232-8652-0cf53219e7bf) | `/producer/tasks` | [Producer Tasks API Integration Guide](docs/producer_tasks_api_integration_guide.md) |
+
+## Related Resources
+
+- [Ace Data Cloud Developer Platform](https://platform.acedata.cloud)
+- [Ace Data Cloud Docs](https://docs.acedata.cloud)
+- [Status Page](https://status.acedata.cloud)
+- [Ace Data Cloud GitHub Organization](https://github.com/AceDataCloud)
+
+## Support
+
+If you meet any issue, please check [support info](https://platform.acedata.cloud/support) or browse the latest documentation on [docs.acedata.cloud](https://docs.acedata.cloud)

--- a/producer/docs/producer_audios_generation_api_integration_guide.md
+++ b/producer/docs/producer_audios_generation_api_integration_guide.md
@@ -1,0 +1,104 @@
+# Producer Audios Generation API Integration Instructions
+
+This article introduces the Producer Audios Generation API integration instructions, which generate AI songs from a text prompt or custom lyrics, with support for instrumental tracks, covers, extensions, and section replacement.
+
+## Application Process
+
+To use the Producer Audios Generation API, apply for the corresponding service on the [Producer Audios Generation API](https://platform.acedata.cloud/documents/01d96900-9f8c-41d7-814c-95c7a885ba61) page. After entering the page, click the "Acquire" button.
+
+If you are not logged in or registered, you will be automatically redirected to the login page inviting you to register and log in. After logging in or registering, you will be automatically returned to the current page.
+
+There is a free quota available for first-time applicants, allowing you to use this API for free. **One API key can call every service on the platform — you do not need to apply separately for each service.**
+
+## Basic Usage
+
+The most basic usage is to input an `action` plus a `prompt`. The request body fields are described below:
+
+- `action`: the operation type. `generate` (new song), `cover`, `extend`, `replace_section`.
+- `prompt`: the song description used when `custom` is false.
+- `model`: the model used to generate the song (e.g. `FUZZ-2.0 Pro`). Defaults to the highest-quality model.
+- `custom`: enable custom lyrics mode (`true` / `false`).
+- `lyric`: custom lyrics with `[Verse]`, `[Chorus]`, `[Bridge]`, `[Outro]` tags.
+- `title`: song title.
+- `instrumental`: produce a pure instrumental track with no vocals.
+- `audio_id`: an existing audio ID, required for `extend` / `cover` / `replace_section`.
+- `continue_at`: extension start point, in seconds.
+- `replace_section_start` / `replace_section_end`: time range to regenerate, in seconds.
+- `lyrics_strength`, `sound_strength`, `weirdness`: 0–1 creative controls.
+- `seed`: seed for reproducibility.
+- `callback_url`: an asynchronous callback URL. When provided, the API returns immediately with a `task_id` and POSTs the result when generation completes.
+- `async`: optional. When `true`, the API returns immediately with a `task_id`; poll the result with the Producer Tasks API.
+
+### Request Example
+
+```bash
+curl -X POST 'https://api.acedata.cloud/producer/audios' \
+  -H 'accept: application/json' \
+  -H 'authorization: Bearer {token}' \
+  -H 'content-type: application/json' \
+  -d '{
+    "action": "generate",
+    "prompt": "chill lo-fi hip hop with rain sounds and soft piano"
+  }'
+```
+
+### Response Example
+
+```json
+{
+  "data": [
+    {
+      "id": "75d8e08f-b25f-450e-9496-7b52e393098b",
+      "lyric": "[Verse]\nSleigh bells ringin', choirs singin'\n...",
+      "audio_url": "https://platform.cdn.acedata.cloud/producer/song.mp3",
+      "video_url": "https://platform.cdn.acedata.cloud/producer/song.mp4",
+      "image_url": "https://platform.cdn.acedata.cloud/producer/cover.jpg",
+      "title": "Song Title",
+      "style": "electronic, dance",
+      "model": "FUZZ-2.0 Pro"
+    }
+  ]
+}
+```
+
+The returned `data` array contains each generated track's `id`, `audio_url`, `video_url`, `image_url`, `title`, `lyric`, `style`, and `model`.
+
+## Workflows
+
+### Generate from a Prompt
+
+Send `action: "generate"` with a `prompt` (see the request example above).
+
+### Custom Lyrics Mode
+
+```json
+{
+  "action": "generate",
+  "custom": true,
+  "title": "Midnight City",
+  "lyric": "[Verse]\nNeon lights reflect on wet streets\n[Chorus]\nMidnight city never sleeps",
+  "instrumental": false
+}
+```
+
+### Extend a Song
+
+```json
+{ "action": "extend", "audio_id": "existing-audio-id", "continue_at": 30 }
+```
+
+### Replace a Section
+
+```json
+{ "action": "replace_section", "audio_id": "existing-audio-id", "replace_section_start": 15, "replace_section_end": 30 }
+```
+
+## Related Endpoints
+
+- `POST /producer/lyrics` — draft lyrics from a `prompt`.
+- `POST /producer/wav` / `POST /producer/videos` — export a finished `audio_id` to WAV / MP4.
+- `POST /producer/upload` — register a reference `audio_url` for cover/extend.
+
+## Support
+
+If you meet any issue, please check [support info](https://platform.acedata.cloud/support) or browse the latest documentation on [docs.acedata.cloud](https://docs.acedata.cloud)

--- a/producer/docs/producer_tasks_api_integration_guide.md
+++ b/producer/docs/producer_tasks_api_integration_guide.md
@@ -1,0 +1,72 @@
+# Producer Tasks API Integration and Usage
+
+The main function of the Producer Tasks API is to query the execution status of tasks by inputting the task ID returned by the Producer Audios Generation API.
+
+This document describes the Producer Tasks API integration, helping you query the status and final result of an asynchronous Producer music generation task.
+
+## Application Process
+
+To use the Producer Tasks API, you first need to apply for the corresponding service on the application page [Producer Audios Generation API](https://platform.acedata.cloud/documents/01d96900-9f8c-41d7-814c-95c7a885ba61), and then copy the task ID returned by the Producer Audios Generation API.
+
+Finally, go to the Tasks API page [Producer Tasks API](https://platform.acedata.cloud/documents/e706d672-d7c9-4232-8652-0cf53219e7bf) to apply for the corresponding service. After entering the page, click the "Acquire" button.
+
+There is a free quota available for first-time applicants, allowing you to use this API for free.
+
+## Request Example
+
+The Producer Tasks API queries the result of a task created by the Producer Audios Generation API. Create the task with `"async": true` (or a `callback_url`), then poll with the returned `id`.
+
+### Request Body
+
+- `id`: a single task ID returned by the Producer Audios Generation API.
+- `ids`: optional array to query multiple tasks at once.
+- `action`: optional operation type.
+
+### Code Example
+
+```bash
+curl -X POST 'https://api.acedata.cloud/producer/tasks' \
+  -H 'accept: application/json' \
+  -H 'authorization: Bearer {token}' \
+  -H 'content-type: application/json' \
+  -d '{
+    "id": "75d8e08f-b25f-450e-9496-7b52e393098b"
+  }'
+```
+
+```python
+import requests
+
+url = "https://api.acedata.cloud/producer/tasks"
+headers = {
+    "accept": "application/json",
+    "authorization": "Bearer {token}",
+    "content-type": "application/json",
+}
+payload = {"id": "75d8e08f-b25f-450e-9496-7b52e393098b"}
+
+response = requests.post(url, json=payload, headers=headers)
+print(response.json())
+```
+
+### Response Example
+
+```json
+{
+  "data": [
+    {
+      "id": "75d8e08f-b25f-450e-9496-7b52e393098b",
+      "state": "complete",
+      "audio_url": "https://platform.cdn.acedata.cloud/producer/song.mp3",
+      "video_url": "https://platform.cdn.acedata.cloud/producer/song.mp4",
+      "title": "Song Title"
+    }
+  ]
+}
+```
+
+Only `state: "complete"` with `success: true` means the job is finished. While `state` is `pending`, the API may return an intermediate `audio_url` (streaming preview) — keep polling every 3–5 seconds until the state is complete.
+
+## Support
+
+If you meet any issue, please check [support info](https://platform.acedata.cloud/support) or browse the latest documentation on [docs.acedata.cloud](https://docs.acedata.cloud)

--- a/shorturl/README.md
+++ b/shorturl/README.md
@@ -1,0 +1,58 @@
+# Short Link Generation API
+
+Turn long URLs into compact, shareable short links served from `suro.id`.
+
+![Platform](https://img.shields.io/badge/platform-Ace%20Data%20Cloud-0f766e?style=flat-square) ![API](https://img.shields.io/badge/type-AI%20API-2563eb?style=flat-square) ![Docs](https://img.shields.io/badge/docs-online-16a34a?style=flat-square)
+
+API home page: [Ace Data Cloud - Short Link Generation](https://platform.acedata.cloud/service/shorturl)
+
+Keywords: shorturl-api, short-link, url-shortener, suro.id, link-generation, rest-api, ai-api, AI API, REST API, Developer API, Ace Data Cloud
+
+## Why Use Short Link Generation on Ace Data Cloud
+
+- Unified developer platform with one API key, billing system, and usage tracking
+- Production-ready API endpoints served from [https://api.acedata.cloud](https://api.acedata.cloud)
+- English integration guides, API references, and service documentation
+- Global-ready workflow for developers building chat, image, video, music, and search products
+
+## Overview
+
+The Short URL API generates a short link for a given long URL. Send the original URL in `content` and receive a shortened `url` in the response.
+
+## Application Process
+
+To use the Short URL API, apply for the corresponding service on the [Short URL API](https://platform.acedata.cloud/documents/d57df7ea-e1ba-4873-905c-d4c072e40450) page. After entering the page, click the "Acquire" button.
+
+There is a free quota available for first-time applicants, allowing you to use this API for free.
+
+## Quick Start
+
+- Base URL: [https://api.acedata.cloud](https://api.acedata.cloud)
+- Service page: [Short Link Generation on Ace Data Cloud](https://platform.acedata.cloud/service/shorturl)
+- Docs: [Developer documentation](https://docs.acedata.cloud)
+
+```bash
+curl --request POST "https://api.acedata.cloud/shorturl" \
+  --header "Authorization: Bearer YOUR_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "content": "https://platform.acedata.cloud/service/shorturl"
+  }'
+```
+
+## APIs and Guides
+
+| API | Path | Integration Guidance |
+| ---- | ---- | ------------ |
+| [Short URL API](https://platform.acedata.cloud/documents/d57df7ea-e1ba-4873-905c-d4c072e40450) | `/shorturl` | [Short URL API Integration Guide](docs/short_url_api_integration_guide.md) |
+
+## Related Resources
+
+- [Ace Data Cloud Developer Platform](https://platform.acedata.cloud)
+- [Ace Data Cloud Docs](https://docs.acedata.cloud)
+- [Status Page](https://status.acedata.cloud)
+- [Ace Data Cloud GitHub Organization](https://github.com/AceDataCloud)
+
+## Support
+
+If you meet any issue, please check [support info](https://platform.acedata.cloud/support) or browse the latest documentation on [docs.acedata.cloud](https://docs.acedata.cloud)

--- a/shorturl/docs/short_url_api_integration_guide.md
+++ b/shorturl/docs/short_url_api_integration_guide.md
@@ -1,0 +1,44 @@
+# Short URL API Integration Instructions
+
+This article introduces the Short URL API integration instructions, which generates a compact short link for a given long URL.
+
+## Application Process
+
+To use the Short URL API, apply for the corresponding service on the [Short URL API](https://platform.acedata.cloud/documents/d57df7ea-e1ba-4873-905c-d4c072e40450) page. After entering the page, click the "Acquire" button.
+
+If you are not logged in or registered, you will be automatically redirected to the login page inviting you to register and log in. After logging in or registering, you will be automatically returned to the current page.
+
+There is a free quota available for first-time applicants, allowing you to use this API for free. **One API key can call every service on the platform — you do not need to apply separately for each service.**
+
+## Basic Usage
+
+The most basic usage is to send the original URL in `content`. The result is the short link. The request body fields are described below:
+
+- `content`: the long URL to shorten (required).
+
+### Request Example
+
+```bash
+curl -X POST 'https://api.acedata.cloud/shorturl' \
+  -H 'accept: application/json' \
+  -H 'authorization: Bearer {token}' \
+  -H 'content-type: application/json' \
+  -d '{
+    "content": "https://platform.acedata.cloud/service/shorturl"
+  }'
+```
+
+### Response Example
+
+```json
+{
+  "data": { "url": "https://suro.id/abc123" },
+  "success": true
+}
+```
+
+The shortened link is returned in `data.url`.
+
+## Support
+
+If you meet any issue, please check [support info](https://platform.acedata.cloud/support) or browse the latest documentation on [docs.acedata.cloud](https://docs.acedata.cloud)

--- a/sync.yaml
+++ b/sync.yaml
@@ -55,3 +55,23 @@ mappings:
     exclude:
       - .github
       - .gitbooks
+  producer:
+    repo: AceDataCloud/ProducerAPI
+    exclude:
+      - .github
+      - .gitbooks
+  fish:
+    repo: AceDataCloud/FishAPI
+    exclude:
+      - .github
+      - .gitbooks
+  face:
+    repo: AceDataCloud/FaceAPI
+    exclude:
+      - .github
+      - .gitbooks
+  shorturl:
+    repo: AceDataCloud/ShortURLAPI
+    exclude:
+      - .github
+      - .gitbooks


### PR DESCRIPTION
Adds per-service API guide dirs + sync.yaml mirror rows for **producer, fish, face, shorturl**. **seedream** already complete (images + tasks) — verified, no change.

## Dirs added
- `producer/` README + audios + tasks guides
- `fish/` README + tts + tasks guides
- `face/` README + swap + beautify guides (+ links for analyze/age/gender/cartoon/detect-live)
- `shorturl/` README + guide
- `sync.yaml`: ProducerAPI, FishAPI, FaceAPI, ShortURLAPI rows (seedream already present)

All endpoints/UUIDs pulled from `PlatformBackend/cost/service_api_mapping.json`; examples from `openapi/*.json`. No fabrication.

## 🤖 对抗评审
- Reviewer: Codex hit usage limit → self-review fallback.
- Checked: 11 paths/UUIDs match mapping; sync repo names match created subrepos; no fabricated responses (all from openapi examples); markdown links valid.
- VERDICT: CLEAN.