### PR TITLE
chore: register kling/hailuo/claude/gemini API mirror subrepos

### DIFF
--- a/sync.yaml
+++ b/sync.yaml
@@ -75,3 +75,23 @@ mappings:
     exclude:
       - .github
       - .gitbooks
+  kling:
+    repo: AceDataCloud/KlingAPI
+    exclude:
+      - .github
+      - .gitbooks
+  hailuo:
+    repo: AceDataCloud/HailuoAPI
+    exclude:
+      - .github
+      - .gitbooks
+  claude:
+    repo: AceDataCloud/ClaudeAPI
+    exclude:
+      - .github
+      - .gitbooks
+  gemini:
+    repo: AceDataCloud/GeminiAPI
+    exclude:
+      - .github
+      - .gitbooks


### PR DESCRIPTION
## What
Dirs kling, hailuo, claude, gemini have docs but were not in sync.yaml. Map each to its <Name>API mirror subrepo (mirror exclude .github/.gitbooks).

## Subrepos
- KlingAPI: existed
- HailuoAPI / ClaudeAPI / GeminiAPI: created (public)

## 🤖 对抗评审
VERDICT: CLEAN — additive YAML rows only, identical pattern to existing 15 mappings; all 4 target repos confirmed to exist before merge.