### PR TITLE
chore: map webextrator to WebExtratorAPI

### DIFF
--- a/sync.yaml
+++ b/sync.yaml
@@ -95,3 +95,8 @@ mappings:
     exclude:
       - .github
       - .gitbooks
+  webextrator:
+    repo: AceDataCloud/WebExtratorAPI
+    exclude:
+      - .github
+      - .gitbooks


### PR DESCRIPTION
webextrator has 3 guide docs but no subrepo mapping. Add WebExtratorAPI mapping. CLEAN.