### PR TITLE
feat(coze): add AceData Cloud Suno plugin for Coze/扣子 (OpenAPI import)

### DIFF
--- a/coze/README.md
+++ b/coze/README.md
@@ -1,0 +1,54 @@
+# AceData Cloud — Coze / 扣子 Plugins
+
+Import AceData Cloud's AI APIs into [Coze](https://www.coze.com) / [扣子](https://www.coze.cn)
+as plugins, so your Coze bots and workflows can generate music, images and video —
+and later search the web — through a single Bearer token.
+
+Coze imports **standard OpenAPI 3.0** schemas, so every file here can be imported
+directly with no code. We start with **Suno (AI music)**; more services follow the
+exact same pattern (one `<service>.yaml` per plugin).
+
+## Plugins
+
+| File | Tool (`operationId`) | AceData API | What it does |
+|---|---|---|---|
+| [`suno.yaml`](./suno.yaml) | `generateMusic` | `POST /suno/audios` | Generate a full song from a prompt or custom lyrics |
+
+## Import into Coze (扣子)
+
+1. **Get an API token.** Create one at
+   <https://platform.acedata.cloud/console/credentials> — a per-service
+   `api.acedata.cloud` token. Keep it secret.
+2. **Create the plugin from the schema.**
+   - Coze.com: **Development → Plugins → Create plugin → Import**, then upload the
+     `.yaml` (or paste its contents).
+   - 扣子 (coze.cn):「**资源库 → 插件 → 创建插件 → 导入**」，上传或粘贴 `.yaml`。
+3. **Configure authorization.** Choose **Service** auth with:
+   - Location: **Header**
+   - Parameter name: **`Authorization`**
+   - Service token / value: **`Bearer <your api.acedata.cloud token>`**
+     (include the literal `Bearer ` prefix).
+4. **Test.** Coze turns each `operationId` into a callable tool. Run **Test** with
+   a minimal payload, e.g. `{ "prompt": "a lofi track for studying" }`, and confirm
+   the response contains an `audio_url`.
+5. **Publish.** Publish the plugin to the Coze plugin store (扣子插件商店) so other
+   users can install it into their own bots and workflows.
+
+## Notes
+
+- **Synchronous by design.** These endpoints return the result inline (the `200`
+  body already contains `audio_url`), which is what Coze tools expect. Do **not**
+  add `callback_url` / `async` to the schema — that switches the API into webhook
+  mode and Coze would only receive a task id.
+- **One token, all services.** The base URL is `https://api.acedata.cloud` and the
+  same token style works across services, so additional plugins here reuse the same
+  auth setup.
+- **Real descriptions.** These schemas hand-write human-readable descriptions on
+  purpose — the platform's internal OpenAPI specs use `$t(...)` i18n placeholders
+  that would otherwise show up literally as tool/parameter names inside Coze.
+
+## Roadmap
+
+Same pattern, one file each: `flux.yaml` (image), `luma.yaml` / `veo.yaml` (video),
+`serp.yaml` (web search). Contributions welcome — copy `suno.yaml`, swap the path,
+parameters and descriptions, and add a row to the table above.

--- a/coze/suno.yaml
+++ b/coze/suno.yaml
@@ -1,0 +1,125 @@
+openapi: 3.0.1
+info:
+  title: AceData Suno — AI Music Generation
+  description: >-
+    Generate full songs (vocals + instrumental) from a text prompt or your own
+    lyrics using Suno models, powered by AceData Cloud
+    (https://platform.acedata.cloud). Import this schema into Coze / 扣子 as a
+    plugin to let your bots and workflows create music on demand.
+  version: "1.0.0"
+servers:
+  - url: https://api.acedata.cloud
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+security:
+  - bearerAuth: []
+paths:
+  /suno/audios:
+    post:
+      operationId: generateMusic
+      summary: Generate a song from a text prompt or lyrics
+      description: >-
+        Create AI-generated music (usually two variations) from a short text
+        prompt, or from your own lyrics in custom mode. When `async` is not set,
+        the response returns synchronously and already contains the audio URLs.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                prompt:
+                  type: string
+                  description: >-
+                    What the song should be about, in natural language, e.g.
+                    "an upbeat pop song about summer road trips". Used when
+                    `custom` is false; ignored in custom mode.
+                  example: an upbeat pop song about summer road trips
+                model:
+                  type: string
+                  enum:
+                    - chirp-v5-5
+                    - chirp-v5
+                    - chirp-v4-5-plus
+                    - chirp-v4-5
+                    - chirp-v4
+                    - chirp-v3-5
+                    - chirp-v3-0
+                  default: chirp-v5-5
+                  description: Suno model version. Newer versions generally sound better.
+                custom:
+                  type: boolean
+                  default: false
+                  description: >-
+                    When true, use `lyric`, `style` and `title` exactly as given
+                    (custom mode) instead of generating from `prompt`.
+                lyric:
+                  type: string
+                  description: >-
+                    Full lyrics to sing, used in custom mode. Use section tags
+                    like [Verse], [Chorus], [Bridge] to structure the song.
+                style:
+                  type: string
+                  description: >-
+                    Musical style / genre, e.g. "uplifting orchestral with
+                    sleigh bells and warm strings".
+                title:
+                  type: string
+                  description: Song title, used in custom mode.
+                instrumental:
+                  type: boolean
+                  default: false
+                  description: When true, generate an instrumental track with no vocals.
+                vocal_gender:
+                  type: string
+                  description: >-
+                    Preferred vocal gender, e.g. "male" or "female". Leave empty
+                    to let the model decide.
+      responses:
+        "200":
+          description: The generated songs, including playable audio URLs.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    description: Whether the request succeeded.
+                  task_id:
+                    type: string
+                    description: Unique id of this generation task.
+                  trace_id:
+                    type: string
+                    description: Trace id for support / debugging.
+                  data:
+                    type: array
+                    description: The generated songs (usually two variations).
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          description: Unique id of the song.
+                        title:
+                          type: string
+                          description: Song title.
+                        audio_url:
+                          type: string
+                          description: URL of the generated MP3 audio.
+                        image_url:
+                          type: string
+                          description: Cover image URL.
+                        lyric:
+                          type: string
+                          description: The lyrics of the song.
+                        duration:
+                          type: number
+                          description: Length of the song in seconds.
+                        model:
+                          type: string
+                          description: The model that produced the song.


### PR DESCRIPTION
## What

The first **Coze / 扣子 plugin** for AceData Cloud: a standalone OpenAPI 3.0 schema
([`APIs/coze/suno.yaml`](./coze/suno.yaml)) that Coze imports directly to give bots
and workflows a `generateMusic` tool, plus a bilingual import/publish guide
([`APIs/coze/README.md`](./coze/README.md)).

## Why

Ecosystem reach — Coze (especially 扣子 / coze.cn) is a large bot/workflow
marketplace we weren't in. Coze imports **standard OpenAPI 3.0**, so we reuse our
existing APIs with a hand-written, real-description schema (the platform's internal
specs use `$t(...)` i18n placeholders that would otherwise show up literally as tool
names in Coze). Suno (music) is the first plugin; the README documents the
copy-one-file pattern to follow for flux / luma / veo / serp.

## Faithful to the real API

Parameters, the `model` enum, and response fields are copied from the real
`/suno/audios` spec (`PlatformBackend/openapi/09a26295-…json`). The endpoint is
**synchronous** (the response already contains `audio_url`) — no `callback_url` /
`async`, which is exactly what Coze tools expect.

## 🤖 对抗评审

Reviewer: Claude Explore subagent (codex unavailable on this host).

- **OpenAPI validity:** structurally valid 3.0.1 (info / servers / paths /
  `operationId` / requestBody / responses / `bearerAuth` / top-level security). CLEAN.
- **Faithfulness:** `model` enum, parameter names, and response fields all match the
  real spec. **RISK found & fixed:** the draft marked `prompt` as `required`, but the
  real API has `required: []` (all optional) — that would force `prompt` even in
  custom mode (where it's ignored). Removed it to match the source of truth; mode
  guidance stays in the operation/parameter descriptions.
- **README:** "Coze imports standard OpenAPI 3.0" and the Service / Header /
  `Authorization: Bearer <token>` auth setup are accurate and non-fabricated; the
  steps are appropriately hedged. CLEAN.

**VERDICT: CLEAN** (sole RISK fixed).
