### PR TITLE
feat(coze): image plugin (GPT Image / Nano Banana / DALL·E)

### DIFF
--- a/coze/README.md
+++ b/coze/README.md
@@ -5,14 +5,16 @@ as plugins, so your Coze bots and workflows can generate music, images and video
 and later search the web — through a single Bearer token.
 
 Coze imports **standard OpenAPI 3.0** schemas, so every file here can be imported
-directly with no code. We start with **Suno (AI music)**; more services follow the
-exact same pattern (one `<service>.yaml` per plugin).
+directly with no code. We ship **Suno (music)** and **image generation (GPT Image /
+Nano Banana / DALL·E)**; more services follow the exact same pattern (one
+`<service>.yaml` per plugin).
 
 ## Plugins
 
 | File | Tool (`operationId`) | AceData API | What it does |
 |---|---|---|---|
 | [`suno.yaml`](./suno.yaml) | `generateMusic` | `POST /suno/audios` | Generate a full song from a prompt or custom lyrics |
+| [`image.yaml`](./image.yaml) | `generateImage` | `POST /openai/images/generations` | Generate images — GPT Image, Nano Banana or DALL·E (pick the model) |
 
 ## Import into Coze (扣子)
 
@@ -37,9 +39,9 @@ exact same pattern (one `<service>.yaml` per plugin).
 ## Notes
 
 - **Synchronous by design.** These endpoints return the result inline (the `200`
-  body already contains `audio_url`), which is what Coze tools expect. Do **not**
-  add `callback_url` / `async` to the schema — that switches the API into webhook
-  mode and Coze would only receive a task id.
+  body already contains the `audio_url` / image `url`), which is what Coze tools
+  expect. Do **not** add `callback_url` / `async` to the schema — that switches the
+  API into webhook mode and Coze would only receive a task id.
 - **One token, all services.** The base URL is `https://api.acedata.cloud` and the
   same token style works across services, so additional plugins here reuse the same
   auth setup.
@@ -47,8 +49,25 @@ exact same pattern (one `<service>.yaml` per plugin).
   purpose — the platform's internal OpenAPI specs use `$t(...)` i18n placeholders
   that would otherwise show up literally as tool/parameter names inside Coze.
 
-## Roadmap
+## Roadmap & priorities
 
-Same pattern, one file each: `flux.yaml` (image), `luma.yaml` / `veo.yaml` (video),
-`serp.yaml` (web search). Contributions welcome — copy `suno.yaml`, swap the path,
-parameters and descriptions, and add a row to the table above.
+AceData Cloud already ships a batch of plugins **live in the Coze store** — Suno,
+Midjourney, DeepSeek, Grok, SERP — each with real usage (Suno alone: ~789 installs /
+157 calls). This folder is the **versioned source** for their OpenAPI schemas so the
+team can re-import and update them consistently instead of hand-editing in the Coze UI.
+
+Highest-value services to add next, by market traction + platform fit (Coze is a
+ByteDance product, so ByteDance's own Seedream / Seedance fit especially well):
+
+| Service | Category | Why |
+|---|---|---|
+| Seedream | image | ByteDance image — platform fit |
+| Sora | video | Top video buzz |
+| Kling | video | Leading China video model |
+| Seedance | video | ByteDance video — platform fit |
+| Veo | video | Google video |
+| Flux | image | Strong open image model |
+
+Same pattern, one file each — copy an existing `.yaml`, swap the path, parameters and
+descriptions (take **real** params + endpoint from `PlatformBackend/openapi/<uuid>.json`,
+never invent them), and add a row to the Plugins table above.

--- a/coze/image.yaml
+++ b/coze/image.yaml
@@ -1,0 +1,126 @@
+openapi: 3.0.1
+info:
+  title: AceData Image — GPT Image, Nano Banana & DALL·E
+  description: >-
+    Generate images from a text prompt using OpenAI GPT Image
+    (gpt-image-1 / 1.5 / 2), Google Nano Banana (nano-banana / -2 / -pro) or
+    DALL·E — one endpoint, just pick the model — powered by AceData Cloud
+    (https://platform.acedata.cloud). Import this schema into Coze / 扣子 as a
+    plugin to let your bots and workflows generate images on demand.
+  version: "1.0.0"
+servers:
+  - url: https://api.acedata.cloud
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+security:
+  - bearerAuth: []
+paths:
+  /openai/images/generations:
+    post:
+      operationId: generateImage
+      summary: Generate an image from a text prompt
+      description: >-
+        Create one or more images from a text prompt. Pick the model — GPT Image,
+        Nano Banana or DALL·E. When `async` is not set, the response returns
+        synchronously and already contains the image URLs.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - prompt
+                - model
+              properties:
+                prompt:
+                  type: string
+                  description: >-
+                    Text description of the image to generate. GPT Image models
+                    support up to 32000 characters.
+                  example: A cute baby sea otter
+                model:
+                  type: string
+                  enum:
+                    - gpt-image-2
+                    - gpt-image-1.5
+                    - gpt-image-1
+                    - nano-banana-pro
+                    - nano-banana-2
+                    - nano-banana
+                    - dall-e-3
+                    - dall-e-2
+                  default: gpt-image-2
+                  description: Which image model to use.
+                size:
+                  type: string
+                  default: auto
+                  description: >-
+                    Image size as WIDTHxHEIGHT (e.g. 1024x1024, 1024x1536,
+                    1536x1024) or "auto".
+                  example: 1024x1024
+                quality:
+                  type: string
+                  enum:
+                    - auto
+                    - high
+                    - medium
+                    - low
+                    - hd
+                    - standard
+                  default: auto
+                  description: Rendering quality.
+                background:
+                  type: string
+                  enum:
+                    - auto
+                    - transparent
+                    - opaque
+                  default: auto
+                  description: >-
+                    Background handling. Use "transparent" for cut-out PNGs
+                    (GPT Image only).
+                n:
+                  type: integer
+                  minimum: 1
+                  maximum: 10
+                  default: 1
+                  description: How many images to generate.
+                output_format:
+                  type: string
+                  enum:
+                    - png
+                    - jpeg
+                    - webp
+                  default: png
+                  description: Output image file format.
+      responses:
+        "200":
+          description: The generated images.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  created:
+                    type: number
+                    description: Unix timestamp when the images were created.
+                  data:
+                    type: array
+                    description: The generated images.
+                    items:
+                      type: object
+                      properties:
+                        url:
+                          type: string
+                          description: >-
+                            URL of the generated image (returned when
+                            response_format is "url", the default).
+                        revised_prompt:
+                          type: string
+                          description: >-
+                            The prompt actually used to generate the image, if it
+                            was revised.


### PR DESCRIPTION
## What

Adds a **Coze / 扣子 image-generation plugin** to the versioned plugin-spec folder
started in #450:

- [`coze/image.yaml`](./coze/image.yaml) — `generateImage` (`POST /openai/images/generations`).
  **One schema covers GPT Image (gpt-image-1 / 1.5 / 2), Nano Banana (nano-banana / -2 /
  -pro) and DALL·E** — just pick the `model`. Synchronous: the 200 body already contains
  the image URLs.
- Updates [`coze/README.md`](./coze/README.md): adds the image plugin row and a
  market-priority roadmap.

## Why

GPT Image and Nano Banana were specifically requested as the next Coze plugins. They
turn out to be the **same AceData endpoint** (`/openai/images/generations`, switched by
`model`), so one plugin covers both plus DALL·E.

Context: AceData already has **Suno / Midjourney / DeepSeek / Grok / SERP live in the
Coze store** with real usage; this folder is their versioned OpenAPI source. `image.yaml`
is net-new coverage.

## Faithful to the real API

Parameters, the `model` enum, and response fields are copied from the real spec
`PlatformBackend/openapi/8f01fe72-…json`. No `callback_url` / `async` (synchronous URLs,
which is what Coze tools expect).

## 🤖 对抗评审

Reviewer: Claude Explore subagent (codex unavailable on this host).

- Valid OpenAPI 3.0.1 (info / servers / paths / `operationId` / requestBody / responses /
  `bearerAuth`). CLEAN.
- `model` enum is a faithful subset of the real enum (gpt-image + nano-banana + dall-e;
  omitted only the internal `:reverse` / `:official` variants); `quality` / `background` /
  `output_format` enums, `n` bounds and `required: [prompt, model]` all match the real
  spec; response (`created`, `data[].url`, `revised_prompt`) matches. No invented values.
  CLEAN.

**VERDICT: CLEAN**
