### PR TITLE
feat(coze): 6 more plugin specs — Seedream/Flux/Sora/Kling/Veo/Seedance

### DIFF
--- a/coze/README.md
+++ b/coze/README.md
@@ -5,9 +5,9 @@ as plugins, so your Coze bots and workflows can generate music, images and video
 and later search the web — through a single Bearer token.
 
 Coze imports **standard OpenAPI 3.0** schemas, so every file here can be imported
-directly with no code. We ship **Suno (music)** and **image generation (GPT Image /
-Nano Banana / DALL·E)**; more services follow the exact same pattern (one
-`<service>.yaml` per plugin).
+directly with no code. We ship **music (Suno)**, **image** (GPT Image / Nano Banana /
+DALL·E / Seedream / Flux) and **video** (Sora / Kling / Veo / Seedance) — one
+`<service>.yaml` per plugin, all synchronous.
 
 ## Plugins
 
@@ -15,6 +15,12 @@ Nano Banana / DALL·E)**; more services follow the exact same pattern (one
 |---|---|---|---|
 | [`suno.yaml`](./suno.yaml) | `generateMusic` | `POST /suno/audios` | Generate a full song from a prompt or custom lyrics |
 | [`image.yaml`](./image.yaml) | `generateImage` | `POST /openai/images/generations` | Generate images — GPT Image, Nano Banana or DALL·E (pick the model) |
+| [`seedream.yaml`](./seedream.yaml) | `generateImage` | `POST /seedream/images` | Generate images with ByteDance Seedream (Doubao) |
+| [`flux.yaml`](./flux.yaml) | `generateImage` | `POST /flux/images` | Generate or edit images with Flux |
+| [`sora.yaml`](./sora.yaml) | `generateVideo` | `POST /sora/videos` | Generate videos with OpenAI Sora |
+| [`kling.yaml`](./kling.yaml) | `generateVideo` | `POST /kling/videos` | Generate videos with Kuaishou Kling |
+| [`veo.yaml`](./veo.yaml) | `generateVideo` | `POST /veo/videos` | Generate videos with Google Veo |
+| [`seedance.yaml`](./seedance.yaml) | `generateVideo` | `POST /seedance/videos` | Generate videos with ByteDance Seedance |
 
 ## Import into Coze (扣子)
 
@@ -56,18 +62,11 @@ Midjourney, DeepSeek, Grok, SERP — each with real usage (Suno alone: ~789 inst
 157 calls). This folder is the **versioned source** for their OpenAPI schemas so the
 team can re-import and update them consistently instead of hand-editing in the Coze UI.
 
-Highest-value services to add next, by market traction + platform fit (Coze is a
-ByteDance product, so ByteDance's own Seedream / Seedance fit especially well):
+The six highest-value services by market traction + platform fit — **Seedream, Flux,
+Sora, Kling, Veo, Seedance** (Coze is a ByteDance product, so ByteDance's own Seedream
+/ Seedance fit especially well) — are now shipped in the Plugins table above.
 
-| Service | Category | Why |
-|---|---|---|
-| Seedream | image | ByteDance image — platform fit |
-| Sora | video | Top video buzz |
-| Kling | video | Leading China video model |
-| Seedance | video | ByteDance video — platform fit |
-| Veo | video | Google video |
-| Flux | image | Strong open image model |
-
-Same pattern, one file each — copy an existing `.yaml`, swap the path, parameters and
-descriptions (take **real** params + endpoint from `PlatformBackend/openapi/<uuid>.json`,
-never invent them), and add a row to the Plugins table above.
+To add more, same pattern, one file each — copy an existing `.yaml`, swap the path,
+parameters and descriptions (take **real** params + endpoint from
+`PlatformBackend/openapi/<uuid>.json`, never invent them), and add a row to the Plugins
+table above. Next candidates: Hailuo, Luma, Wan (video), Fish (audio).

--- a/coze/flux.yaml
+++ b/coze/flux.yaml
@@ -1,0 +1,91 @@
+openapi: 3.0.1
+info:
+  title: AceData Flux — AI Image Generation
+  description: >-
+    Generate or edit images from a text prompt using Black Forest Labs Flux
+    models, powered by AceData Cloud (https://platform.acedata.cloud). Import this
+    schema into Coze / 扣子 as a plugin.
+  version: "1.0.0"
+servers:
+  - url: https://api.acedata.cloud
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+security:
+  - bearerAuth: []
+paths:
+  /flux/images:
+    post:
+      operationId: generateImage
+      summary: Generate or edit an image from a text prompt
+      description: >-
+        Create an image from a text prompt (`action` = generate), or edit an
+        existing image (`action` = edit, with `image_url`). When `async` is not
+        set, the response returns synchronously and already contains the image URL.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - prompt
+                - action
+              properties:
+                prompt:
+                  type: string
+                  description: Text description of the image to generate or the edit to apply.
+                  example: a white siamese cat
+                action:
+                  type: string
+                  enum:
+                    - generate
+                    - edit
+                  default: generate
+                  description: generate a new image, or edit an existing one (needs image_url).
+                model:
+                  type: string
+                  enum:
+                    - flux-2-pro
+                    - flux-2-max
+                    - flux-2-flex
+                    - flux-2-klein
+                    - flux-pro
+                    - flux-dev
+                    - flux-kontext-pro
+                    - flux-kontext-max
+                  default: flux-2-pro
+                  description: Flux model version.
+                size:
+                  type: string
+                  description: Image size as WIDTHxHEIGHT, e.g. 1024x1024.
+                  example: 1024x1024
+                count:
+                  type: integer
+                  description: How many images to generate.
+                image_url:
+                  type: string
+                  description: Source image URL to edit (for action = edit).
+      responses:
+        "200":
+          description: The generated image.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  task_id:
+                    type: string
+                  data:
+                    type: array
+                    description: The generated images.
+                    items:
+                      type: object
+                      properties:
+                        image_url:
+                          type: string
+                          description: URL of the generated image.

--- a/coze/kling.yaml
+++ b/coze/kling.yaml
@@ -1,0 +1,109 @@
+openapi: 3.0.1
+info:
+  title: AceData Kling — AI Video Generation
+  description: >-
+    Generate videos from a text prompt using Kuaishou Kling models, powered by
+    AceData Cloud (https://platform.acedata.cloud). Import this schema into Coze /
+    扣子 as a plugin.
+  version: "1.0.0"
+servers:
+  - url: https://api.acedata.cloud
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+security:
+  - bearerAuth: []
+paths:
+  /kling/videos:
+    post:
+      operationId: generateVideo
+      summary: Generate a video from a text prompt
+      description: >-
+        Create a video with Kling. For text-to-video keep `action` = text2video
+        and give a `prompt`; for image-to-video set `action` = image2video and a
+        `start_image_url`. When `async` is not set, the response returns
+        synchronously and already contains the video URL.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - prompt
+              properties:
+                prompt:
+                  type: string
+                  description: Text description of the video to generate.
+                  example: A white ceramic coffee mug on a marble countertop, camera slowly orbiting 360 degrees.
+                action:
+                  type: string
+                  enum:
+                    - text2video
+                    - image2video
+                    - extend
+                  default: text2video
+                  description: Generation mode.
+                model:
+                  type: string
+                  enum:
+                    - kling-v1
+                    - kling-v1-6
+                    - kling-v2-master
+                    - kling-v2-1-master
+                    - kling-v2-5-turbo
+                    - kling-v2-6
+                    - kling-v3
+                    - kling-v3-omni
+                    - kling-video-o1
+                  default: kling-v2-6
+                  description: Kling model version.
+                duration:
+                  type: number
+                  enum:
+                    - 5
+                    - 10
+                  description: Video length in seconds.
+                aspect_ratio:
+                  type: string
+                  enum:
+                    - "16:9"
+                    - "9:16"
+                    - "1:1"
+                  description: Video aspect ratio.
+                mode:
+                  type: string
+                  enum:
+                    - std
+                    - pro
+                    - 4k
+                  description: Rendering quality mode.
+                start_image_url:
+                  type: string
+                  description: First-frame image URL (for action = image2video).
+                negative_prompt:
+                  type: string
+                  description: What to avoid in the video.
+      responses:
+        "200":
+          description: The generated video.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  video_url:
+                    type: string
+                    description: URL of the generated video.
+                  duration:
+                    type: string
+                    description: Video length in seconds.
+                  state:
+                    type: string
+                    description: Generation state (e.g. succeed).
+                  task_id:
+                    type: string

--- a/coze/seedance.yaml
+++ b/coze/seedance.yaml
@@ -1,0 +1,90 @@
+openapi: 3.0.1
+info:
+  title: AceData Seedance — AI Video Generation
+  description: >-
+    Generate videos using ByteDance Seedance (Doubao) models, powered by AceData
+    Cloud (https://platform.acedata.cloud). Import this schema into Coze / 扣子 as
+    a plugin.
+  version: "1.0.0"
+servers:
+  - url: https://api.acedata.cloud
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+security:
+  - bearerAuth: []
+paths:
+  /seedance/videos:
+    post:
+      operationId: generateVideo
+      summary: Generate a video from a text prompt
+      description: >-
+        Create a video with Seedance. Provide the input as a `content` array — for
+        text-to-video a single text item is enough. When `async` is not set, the
+        response returns synchronously and already contains the video URL.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - model
+                - content
+              properties:
+                model:
+                  type: string
+                  enum:
+                    - doubao-seedance-2-0-260128
+                    - doubao-seedance-2-0-fast-260128
+                    - doubao-seedance-2-0-mini-260615
+                    - doubao-seedance-1-5-pro-251215
+                    - doubao-seedance-1-0-pro-250528
+                    - doubao-seedance-1-0-pro-fast-251015
+                    - doubao-seedance-1-0-lite-t2v-250428
+                    - doubao-seedance-1-0-lite-i2v-250428
+                  default: doubao-seedance-2-0-260128
+                  description: Seedance model version.
+                content:
+                  type: array
+                  description: >-
+                    Generation input. For text-to-video pass a single text item:
+                    {"type":"text","text":"<your prompt> --rs 720p --rt 16:9 --dur 5"}.
+                    Flags you can append in the text — --rs resolution (480p/720p/1080p),
+                    --rt aspect ratio, --dur seconds, --fps frame rate, --seed.
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - text
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                          - text
+                      text:
+                        type: string
+                        example: A kitten yawning at the camera. --rs 720p --rt 16:9 --dur 5
+      responses:
+        "200":
+          description: The generated video.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  task_id:
+                    type: string
+                  data:
+                    type: array
+                    description: The generated videos.
+                    items:
+                      type: object
+                      properties:
+                        video_url:
+                          type: string
+                          description: URL of the generated video.

--- a/coze/seedream.yaml
+++ b/coze/seedream.yaml
@@ -1,0 +1,93 @@
+openapi: 3.0.1
+info:
+  title: AceData Seedream — AI Image Generation
+  description: >-
+    Generate images from a text prompt using ByteDance Seedream (Doubao) models,
+    powered by AceData Cloud (https://platform.acedata.cloud). Import this schema
+    into Coze / 扣子 as a plugin.
+  version: "1.0.0"
+servers:
+  - url: https://api.acedata.cloud
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+security:
+  - bearerAuth: []
+paths:
+  /seedream/images:
+    post:
+      operationId: generateImage
+      summary: Generate an image from a text prompt
+      description: >-
+        Create an image from a text prompt using a Seedream model. When `async`
+        is not set, the response returns synchronously and already contains the
+        image URL.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - prompt
+                - model
+              properties:
+                prompt:
+                  type: string
+                  description: Text description of the image to generate.
+                  example: a white siamese cat
+                model:
+                  type: string
+                  enum:
+                    - doubao-seedream-5-0-260128
+                    - doubao-seedream-4-5-251128
+                    - doubao-seedream-4-0-250828
+                    - doubao-seedream-3-0-t2i-250415
+                    - doubao-seededit-3-0-i2i-250628
+                  default: doubao-seedream-5-0-260128
+                  description: Seedream model version. Newer versions generally look better.
+                size:
+                  type: string
+                  enum:
+                    - 1K
+                    - 2K
+                    - 3K
+                    - 4K
+                    - adaptive
+                  default: 2K
+                  description: Output resolution tier.
+                seed:
+                  type: integer
+                  description: Optional seed for reproducible results.
+                output_format:
+                  type: string
+                  enum:
+                    - jpeg
+                    - png
+                  description: Output image file format.
+      responses:
+        "200":
+          description: The generated image.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  task_id:
+                    type: string
+                  data:
+                    type: array
+                    description: The generated images.
+                    items:
+                      type: object
+                      properties:
+                        image_url:
+                          type: string
+                          description: URL of the generated image.
+                        prompt:
+                          type: string
+                          description: The prompt used to generate the image.

--- a/coze/sora.yaml
+++ b/coze/sora.yaml
@@ -1,0 +1,98 @@
+openapi: 3.0.1
+info:
+  title: AceData Sora — AI Video Generation
+  description: >-
+    Generate videos from a text prompt using OpenAI Sora models, powered by
+    AceData Cloud (https://platform.acedata.cloud). Import this schema into Coze /
+    扣子 as a plugin.
+  version: "1.0.0"
+servers:
+  - url: https://api.acedata.cloud
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+security:
+  - bearerAuth: []
+paths:
+  /sora/videos:
+    post:
+      operationId: generateVideo
+      summary: Generate a video from a text prompt
+      description: >-
+        Create a video from a text prompt using a Sora model. When `async` is not
+        set, the response returns synchronously and already contains the video URL.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - prompt
+                - model
+              properties:
+                prompt:
+                  type: string
+                  description: Text description of the video to generate.
+                  example: cat running on the river
+                model:
+                  type: string
+                  enum:
+                    - sora-2
+                    - sora-2-pro
+                  default: sora-2
+                  description: Sora model version.
+                duration:
+                  type: integer
+                  enum:
+                    - 4
+                    - 8
+                    - 10
+                    - 12
+                    - 15
+                    - 25
+                  description: Video length in seconds.
+                orientation:
+                  type: string
+                  enum:
+                    - landscape
+                    - portrait
+                  description: Video orientation.
+                size:
+                  type: string
+                  enum:
+                    - small
+                    - large
+                    - 720x1280
+                    - 1280x720
+                    - 1024x1792
+                    - 1792x1024
+                  description: Video resolution.
+      responses:
+        "200":
+          description: The generated video.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  task_id:
+                    type: string
+                  data:
+                    type: array
+                    description: The generated videos.
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        video_url:
+                          type: string
+                          description: URL of the generated video.
+                        state:
+                          type: string
+                          description: Generation state (e.g. succeeded).

--- a/coze/veo.yaml
+++ b/coze/veo.yaml
@@ -1,0 +1,98 @@
+openapi: 3.0.1
+info:
+  title: AceData Veo — AI Video Generation
+  description: >-
+    Generate videos from a text prompt using Google Veo models, powered by
+    AceData Cloud (https://platform.acedata.cloud). Import this schema into Coze /
+    扣子 as a plugin.
+  version: "1.0.0"
+servers:
+  - url: https://api.acedata.cloud
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+security:
+  - bearerAuth: []
+paths:
+  /veo/videos:
+    post:
+      operationId: generateVideo
+      summary: Generate a video from a text prompt
+      description: >-
+        Create a video with Google Veo. For text-to-video keep `action` =
+        text2video and give a `prompt`; for image-to-video set `action` =
+        image2video and provide `image_urls`. When `async` is not set, the
+        response returns synchronously and already contains the video URL.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - prompt
+              properties:
+                prompt:
+                  type: string
+                  description: Text description of the video to generate.
+                  example: A white ceramic coffee mug on a marble counter, camera slowly orbiting 360 degrees.
+                action:
+                  type: string
+                  enum:
+                    - text2video
+                    - image2video
+                  default: text2video
+                  description: Generation mode.
+                model:
+                  type: string
+                  enum:
+                    - veo3-fast
+                    - veo31-fast
+                    - veo31
+                    - veo3
+                    - veo2-fast
+                    - veo31-fast-ingredients
+                  default: veo3-fast
+                  description: Veo model version.
+                resolution:
+                  type: string
+                  enum:
+                    - 4k
+                    - 1080p
+                    - gif
+                  default: 1080p
+                  description: Output resolution.
+                aspect_ratio:
+                  type: string
+                  enum:
+                    - "16:9"
+                    - "9:16"
+                  description: Video aspect ratio.
+                image_urls:
+                  type: array
+                  items:
+                    type: string
+                  description: 1-2 reference images (first frame, or first + last) for action = image2video.
+      responses:
+        "200":
+          description: The generated video.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  task_id:
+                    type: string
+                  data:
+                    type: array
+                    description: The generated videos.
+                    items:
+                      type: object
+                      properties:
+                        video_url:
+                          type: string
+                          description: URL of the generated video.


### PR DESCRIPTION
## What

Adds **6 more Coze / 扣子 plugin specs** to the versioned plugin-spec folder
(`APIs/coze/`), covering the highest-value image + video services:

| File | Tool (`operationId`) | AceData API |
|---|---|---|
| [`seedream.yaml`](./coze/seedream.yaml) | `generateImage` | `POST /seedream/images` |
| [`flux.yaml`](./coze/flux.yaml) | `generateImage` | `POST /flux/images` |
| [`sora.yaml`](./coze/sora.yaml) | `generateVideo` | `POST /sora/videos` |
| [`kling.yaml`](./coze/kling.yaml) | `generateVideo` | `POST /kling/videos` |
| [`veo.yaml`](./coze/veo.yaml) | `generateVideo` | `POST /veo/videos` |
| [`seedance.yaml`](./coze/seedance.yaml) | `generateVideo` | `POST /seedance/videos` |

Plus README updates (plugin table + shipped-roadmap).

## Why

Market decision by traction + platform fit — **Coze is a ByteDance product, so
ByteDance's own Seedream / Seedance fit especially well**. These join the Suno + image
(GPT Image / Nano Banana / DALL·E) plugins already in this folder. All endpoints are
**synchronous** (the 200 body already contains the video/image URL), which is what Coze
tools expect — no `callback_url` / `async`.

## Faithful to the real API

Every path, `model` enum and response field is copied from the real specs under
`PlatformBackend/openapi/`. Intentional, consumer-friendly deviations:

- **kling / veo** use `required: [prompt]` with `action` defaulting to `text2video`
  (the real required is `[action]`; both are real params) — so the LLM reliably supplies
  a prompt for the common text-to-video case.
- **seedance**'s `content` array is simplified to a single `text` item (a real `oneOf`
  variant), with the `--rs/--rt/--dur` flags documented in the field description.

## 🤖 对抗评审

Reviewer: Claude Explore subagent (codex unavailable on this host). Checked all 6 against
their real specs — valid OpenAPI, `model` enum fidelity, params exist, required deviations,
response field names.

- **seedream / sora / kling / seedance:** CLEAN — enums, params and response fields all
  match the real specs.
- **2 RISKs found & fixed:**
  - `veo.yaml` was missing the real model `veo31-fast-ingredients` → **added**.
  - `flux.yaml` response field was `url`; the real API returns `image_url` → **corrected**.

**VERDICT: CLEAN** (both RISKs fixed; the only remaining deltas are the documented
intentional `required`/`content` simplifications).
