### PR TITLE
docs(seedream): add Seedream 5.0 Pro model

### DIFF
--- a/seedream/README.md
+++ b/seedream/README.md
@@ -8,7 +8,7 @@ Keywords: seedream-api, ai-image, image-generation, image-editing, bytedance, do
 
 ## Overview
 
-The Seedream Images API generates and edits ByteDance Seedream (Doubao) images by inputting custom parameters. Models: `doubao-seedream-3-0-t2i-250415`, `doubao-seedream-4-0-250828`, `doubao-seedream-4-5-251128`, `doubao-seedream-5-0-260128`, `doubao-seedream-5.0-lite`, and `doubao-seededit-3-0-i2i-250628` (image edit). The Seedream Tasks API queries async task status.
+The Seedream Images API generates and edits ByteDance Seedream (Doubao) images by inputting custom parameters. Models: `doubao-seedream-3-0-t2i-250415`, `doubao-seedream-4-0-250828`, `doubao-seedream-4-5-251128`, `doubao-seedream-5-0-260128`, `doubao-seedream-5.0-lite`, `doubao-seedream-5-0-pro-260628`, and `doubao-seededit-3-0-i2i-250628` (image edit). The Seedream Tasks API queries async task status.
 
 ## Quick Start
 
@@ -23,6 +23,7 @@ curl --request POST "https://api.acedata.cloud/seedream/images" \
 
 | Model | Notes |
 | ---- | ---- |
+| `doubao-seedream-5-0-pro-260628` | Flagship single image, highest quality (no image sets/streaming/web search) |
 | `doubao-seedream-5-0-260128` | Latest, highest quality (推荐) |
 | `doubao-seedream-5.0-lite` | Lightweight 5.0 |
 | `doubao-seedream-4-5-251128` | 4.5 |

--- a/seedream/docs/seedream_images_generation_api_integration_guide.md
+++ b/seedream/docs/seedream_images_generation_api_integration_guide.md
@@ -10,7 +10,7 @@ Apply for the service on the [Seedream Images API](https://platform.acedata.clou
 
 Request body fields:
 
-- `model`: one of `doubao-seedream-5-0-260128`, `doubao-seedream-5.0-lite`, `doubao-seedream-4-5-251128`, `doubao-seedream-4-0-250828`, `doubao-seedream-3-0-t2i-250415`, `doubao-seededit-3-0-i2i-250628`.
+- `model`: one of `doubao-seedream-5-0-pro-260628`, `doubao-seedream-5-0-260128`, `doubao-seedream-5.0-lite`, `doubao-seedream-4-5-251128`, `doubao-seedream-4-0-250828`, `doubao-seedream-3-0-t2i-250415`, `doubao-seededit-3-0-i2i-250628`.
 - `prompt`: image description (required).
 - `size`: output resolution `1K` / `2K` / `4K`.
 - `image_url`: source image for editing (SeedEdit `doubao-seededit-3-0-i2i-250628`).


### PR DESCRIPTION
Document **Seedream 5.0 Pro** (`doubao-seedream-5-0-pro-260628`) in the Seedream API docs.

## Changes
- `README.md`: intro model list + model table (flagship single image; no image sets/streaming/web-search).
- `docs/seedream_images_generation_api_integration_guide.md`: add Pro to the `model` value list.

Docs-only. **VERDICT: CLEAN.**