### PR TITLE
docs(seedream): drop invalid dot-form model id doubao-seedream-5.0-lite

### DIFF
--- a/seedream/README.md
+++ b/seedream/README.md
@@ -8,7 +8,7 @@ Keywords: seedream-api, ai-image, image-generation, image-editing, bytedance, do
 
 ## Overview
 
-The Seedream Images API generates and edits ByteDance Seedream (Doubao) images by inputting custom parameters. Models: `doubao-seedream-3-0-t2i-250415`, `doubao-seedream-4-0-250828`, `doubao-seedream-4-5-251128`, `doubao-seedream-5-0-260128`, `doubao-seedream-5.0-lite`, `doubao-seedream-5-0-pro-260628`, and `doubao-seededit-3-0-i2i-250628` (image edit). The Seedream Tasks API queries async task status.
+The Seedream Images API generates and edits ByteDance Seedream (Doubao) images by inputting custom parameters. Models: `doubao-seedream-3-0-t2i-250415`, `doubao-seedream-4-0-250828`, `doubao-seedream-4-5-251128`, `doubao-seedream-5-0-260128`, `doubao-seedream-5-0-pro-260628`, and `doubao-seededit-3-0-i2i-250628` (image edit). The Seedream Tasks API queries async task status.
 
 ## Quick Start
 
@@ -25,7 +25,6 @@ curl --request POST "https://api.acedata.cloud/seedream/images" \
 | ---- | ---- |
 | `doubao-seedream-5-0-pro-260628` | Flagship single image, highest quality (no image sets/streaming/web search) |
 | `doubao-seedream-5-0-260128` | Latest, highest quality (推荐) |
-| `doubao-seedream-5.0-lite` | Lightweight 5.0 |
 | `doubao-seedream-4-5-251128` | 4.5 |
 | `doubao-seedream-4-0-250828` | 4.0 |
 | `doubao-seedream-3-0-t2i-250415` | 3.0 text-to-image |

--- a/seedream/docs/seedream_images_generation_api_integration_guide.md
+++ b/seedream/docs/seedream_images_generation_api_integration_guide.md
@@ -10,7 +10,7 @@ Apply for the service on the [Seedream Images API](https://platform.acedata.clou
 
 Request body fields:
 
-- `model`: one of `doubao-seedream-5-0-pro-260628`, `doubao-seedream-5-0-260128`, `doubao-seedream-5.0-lite`, `doubao-seedream-4-5-251128`, `doubao-seedream-4-0-250828`, `doubao-seedream-3-0-t2i-250415`, `doubao-seededit-3-0-i2i-250628`.
+- `model`: one of `doubao-seedream-5-0-pro-260628`, `doubao-seedream-5-0-260128`, `doubao-seedream-4-5-251128`, `doubao-seedream-4-0-250828`, `doubao-seedream-3-0-t2i-250415`, `doubao-seededit-3-0-i2i-250628`.
 - `prompt`: image description (required).
 - `size`: output resolution `1K` / `2K` / `4K`.
 - `image_url`: source image for editing (SeedEdit `doubao-seededit-3-0-i2i-250628`).


### PR DESCRIPTION
Remove the non-canonical `doubao-seedream-5.0-lite` (dot short form) from the Seedream API docs — the deployed worker rejects it (HTTP 400); only the 6 date-suffixed canonical IDs are accepted. `doubao-seedream-5-0-260128` already covers the Lite model.

Docs-only, aligns with PlatformService `ALLOWED_MODELS` / OpenAPI enum / MCP / Clis. **VERDICT: CLEAN.**