### PR TITLE
docs(maestro): add Maestro API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Monorepo for all AceDataCloud API documentation repositories.
 | Directory | Standalone Repo | Description |
 |---|---|---|
 | `luma/` | [LumaAPI](https://github.com/AceDataCloud/LumaAPI) | Luma video generation API docs |
+| `maestro/` | [MaestroAPI](https://github.com/AceDataCloud/MaestroAPI) | Maestro end-to-end AI video production API docs |
 | `suno/` | [SunoAPI](https://github.com/AceDataCloud/SunoAPI) | Suno music generation API docs |
 | `sora/` | [SoraAPI](https://github.com/AceDataCloud/SoraAPI) | Sora video generation API docs |
 | `veo/` | [VeoAPI](https://github.com/AceDataCloud/VeoAPI) | Veo video generation API docs |

--- a/maestro/README.md
+++ b/maestro/README.md
@@ -1,0 +1,93 @@
+# Maestro AI Video Production API
+
+Maestro turns a natural-language brief and optional reference media into a finished video. Its AI director handles planning, scripting, visual assets, voiceover, music, editing, captions, quality checks, rendering, and multilingual variants.
+
+![Platform](https://img.shields.io/badge/platform-Ace%20Data%20Cloud-0f766e?style=flat-square) ![API](https://img.shields.io/badge/type-AI%20API-2563eb?style=flat-square) ![Docs](https://img.shields.io/badge/docs-online-16a34a?style=flat-square)
+
+API home page: [Ace Data Cloud - Maestro](https://platform.acedata.cloud/services/maestro)
+
+Keywords: maestro-api, ai-video, video-production, prompt-to-video, article-to-video, multilingual-video, video-editing, rest-api, ai-api, developer-api, Ace Data Cloud
+
+## Why Use Maestro on Ace Data Cloud
+
+- Produce a complete video instead of a single model-generated shot
+- Create scripts, visuals, narration, music, captions, and edits in one asynchronous workflow
+- Attach public image, video, and audio references
+- Render localized variants from one production
+- Remix, edit, or extend an earlier Maestro task
+- Use one Ace Data Cloud API token, billing system, and task history
+
+## Quick Start
+
+Create an API token in the [Ace Data Cloud console](https://platform.acedata.cloud/console/applications), then submit a video brief:
+
+```bash
+curl --request POST 'https://api.acedata.cloud/maestro/videos' \
+  --header 'Authorization: Bearer YOUR_API_TOKEN' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "prompt": "Create a 30-second beginner-friendly video explaining vector databases. End with one memorable takeaway.",
+    "langs": ["en"],
+    "aspect": "16:9",
+    "duration": 30,
+    "quality": "standard",
+    "scenario": "narrated"
+  }'
+```
+
+The API accepts the job immediately:
+
+```json
+{
+  "success": true,
+  "task_id": "f57e99c4-f60f-4373-a155-17742ce2357d",
+  "trace_id": "70e1cb12-c619-4292-a416-90191205996b"
+}
+```
+
+Query the task until its top-level `status` becomes `succeeded` or `failed`:
+
+```bash
+curl --request POST 'https://api.acedata.cloud/maestro/tasks' \
+  --header 'Authorization: Bearer YOUR_API_TOKEN' \
+  --header 'Content-Type: application/json' \
+  --data '{"id": "f57e99c4-f60f-4373-a155-17742ce2357d", "action": "retrieve"}'
+```
+
+## APIs and Guides
+
+| API | Path | Integration Guide |
+|---|---|---|
+| [Maestro Videos API](https://platform.acedata.cloud/documents/maestro-videos) | `POST /maestro/videos` | [Video production guide](docs/maestro_videos_api_integration_guide.md) |
+| [Maestro Tasks API](https://platform.acedata.cloud/documents/maestro-tasks) | `POST /maestro/tasks` | [Task retrieval guide](docs/maestro_tasks_api_integration_guide.md) |
+
+## Asynchronous Workflow
+
+```text
+POST /maestro/videos
+        |
+        v
+  task_id returned
+        |
+        v
+POST /maestro/tasks  ->  pending/planning/producing  ->  succeeded or failed
+        |                                                   |
+        +---------------- progress -------------------------+
+                                                            |
+                                                            v
+                                             response.data.variants
+```
+
+Task polling and history retrieval do not consume credits. Video jobs are settled after production from the output actually delivered; failed jobs are not charged. See [live Maestro pricing](https://platform.acedata.cloud/services/maestro?tab=pricing) for current rates.
+
+## Related Resources
+
+- [Maestro in Ace Data Cloud Studio](https://studio.acedata.cloud/maestro)
+- [Ace Data Cloud Developer Platform](https://platform.acedata.cloud)
+- [Ace Data Cloud documentation](https://docs.acedata.cloud)
+- [Service status](https://status.acedata.cloud)
+- [Ace Data Cloud GitHub organization](https://github.com/AceDataCloud)
+
+## Support
+
+For integration help, use the [support page](https://platform.acedata.cloud/support) and include the response `trace_id` when available.

--- a/maestro/docs/maestro_tasks_api_integration_guide.md
+++ b/maestro/docs/maestro_tasks_api_integration_guide.md
@@ -1,0 +1,232 @@
+# Maestro Tasks API Integration Guide
+
+`POST https://api.acedata.cloud/maestro/tasks`
+
+The Maestro Tasks API retrieves one video job or lists recent jobs belonging to the authenticated user. Polling and history retrieval are free.
+
+## Authentication
+
+Use the same Ace Data Cloud Bearer token that created the video:
+
+```http
+Authorization: Bearer YOUR_API_TOKEN
+Content-Type: application/json
+Accept: application/json
+```
+
+## Retrieve One Task
+
+Request body:
+
+| Field | Type | Required | Description |
+|---|---|---:|---|
+| `id` | string | yes | `task_id` returned by `POST /maestro/videos` |
+| `action` | string | no | `retrieve`; this is the default when omitted |
+
+```bash
+curl --request POST 'https://api.acedata.cloud/maestro/tasks' \
+  --header 'Authorization: Bearer YOUR_API_TOKEN' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "id": "f57e99c4-f60f-4373-a155-17742ce2357d",
+    "action": "retrieve"
+  }'
+```
+
+Python example:
+
+```python
+import os
+
+import requests
+
+response = requests.post(
+    "https://api.acedata.cloud/maestro/tasks",
+    headers={
+        "Authorization": f"Bearer {os.environ['ACEDATACLOUD_API_TOKEN']}",
+        "Content-Type": "application/json",
+    },
+    json={
+        "id": "f57e99c4-f60f-4373-a155-17742ce2357d",
+        "action": "retrieve",
+    },
+    timeout=30,
+)
+response.raise_for_status()
+print(response.json())
+```
+
+## Task Shape
+
+The following is an illustrative shape. URLs and optional fields vary with the delivered production:
+
+```json
+{
+  "id": "f57e99c4-f60f-4373-a155-17742ce2357d",
+  "trace_id": "70e1cb12-c619-4292-a416-90191205996b",
+  "status": "succeeded",
+  "progress": {
+    "percent": 100,
+    "stage": "producing",
+    "message": "Rendering scene 2",
+    "activity": null,
+    "render": null
+  },
+  "created_at": 1750000000,
+  "elapsed": 312,
+  "request": {
+    "prompt": "Create a beginner-friendly vector database video.",
+    "langs": ["en"],
+    "aspect": "16:9",
+    "duration": 30
+  },
+  "response": {
+    "success": true,
+    "data": {
+      "variants": [
+        {
+          "lang": "en",
+          "aspect": "16:9",
+          "kind": "video",
+          "title": "What is a vector database?",
+          "output_url": "https://cdn.example/video.mp4"
+        }
+      ],
+      "project": {
+        "tarball_url": "https://cdn.example/project.tar.gz",
+        "outputs": ["https://cdn.example/video.mp4"]
+      },
+      "percent": 100,
+      "stage": "producing",
+      "progress": [
+        {"stage": "producing", "message": "Rendering scene 2", "pct": 100, "t": 1750000300}
+      ]
+    }
+  },
+  "agent": null
+}
+```
+
+Key fields:
+
+- `status`: authoritative lifecycle state. Terminal values are `succeeded` and `failed`.
+- `progress.percent`: normalized progress from 0 through 100.
+- `progress.stage`, `message`, `activity`, and `render`: latest available production telemetry. Optional values may be `null`.
+- `request`: normalized creation request stored with the task.
+- `response`: final result or failure information when available.
+- `response.data.variants`: delivered language variants. Read each actual `output_url` from this array.
+- `response.data.project`: project-level artifacts when present.
+- `response.data.progress`: append-only production event history when present.
+
+A succeeded task may retain the name of its last execution stage in `progress.stage`; use top-level `status`, not the stage name, to decide whether the task is complete.
+
+## Polling
+
+Poll at a reasonable cadence and use exponential backoff with jitter. Continue through nonterminal statuses, then stop at `succeeded` or `failed`. Do not create a duplicate video merely because production is taking time.
+
+Example polling logic with application-supplied timing:
+
+```python
+import os
+import random
+import time
+
+import requests
+
+task_id = "f57e99c4-f60f-4373-a155-17742ce2357d"
+delay = float(os.environ["MAESTRO_INITIAL_POLL_DELAY"])
+maximum_delay = float(os.environ["MAESTRO_MAXIMUM_POLL_DELAY"])
+backoff_factor = float(os.environ["MAESTRO_POLL_BACKOFF_FACTOR"])
+
+while True:
+    response = requests.post(
+        "https://api.acedata.cloud/maestro/tasks",
+        headers={"Authorization": f"Bearer {os.environ['ACEDATACLOUD_API_TOKEN']}"},
+        json={"id": task_id, "action": "retrieve"},
+        timeout=30,
+    )
+    response.raise_for_status()
+    task = response.json()
+
+    if task["status"] in {"succeeded", "failed"}:
+        break
+
+    time.sleep(delay + random.random())
+    delay = min(delay * backoff_factor, maximum_delay)
+
+print(task)
+```
+
+Choose these client-side timing values for your workload and current service behavior; the API does not publish fixed polling-interval guarantees.
+
+## List Recent Tasks
+
+Use `retrieve_batch` to list the authenticated user's tasks in reverse creation order.
+
+| Field | Type | Required | Default | Description |
+|---|---|---:|---|---|
+| `action` | string | yes | - | Must be `retrieve_batch` |
+| `limit` | integer | no | `20` | Maximum page size requested |
+| `created_at_min` | integer | no | - | Return tasks newer than this Unix timestamp |
+| `created_at_max` | integer | no | - | Return tasks older than this Unix timestamp; use for pagination |
+
+```bash
+curl --request POST 'https://api.acedata.cloud/maestro/tasks' \
+  --header 'Authorization: Bearer YOUR_API_TOKEN' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "action": "retrieve_batch",
+    "limit": 20
+  }'
+```
+
+Illustrative response shape:
+
+```json
+{
+  "count": 6,
+  "items": [
+    {
+      "id": "f57e99c4-f60f-4373-a155-17742ce2357d",
+      "status": "succeeded",
+      "created_at": 1750000000,
+      "progress": {"percent": 100, "stage": "producing", "message": null},
+      "request": {"prompt": "Create a product video.", "langs": ["en"]},
+      "response": {"success": true, "data": {"variants": []}}
+    }
+  ]
+}
+```
+
+- `count` is the authenticated user's total task count and is independent of any `created_at_min`/`created_at_max` window.
+- `items` contains the requested page in newest-first order.
+- For the next page, pass the oldest returned item's `created_at` as `created_at_max`.
+- Identity comes from the authenticated request. A body-level `user_id` must not be used to select another user's tasks.
+
+## Errors
+
+If a single task is not found, the service returns HTTP 404 with a JSON `detail` message:
+
+```json
+{
+  "detail": "task not found"
+}
+```
+
+Authentication, rate-limit, and infrastructure errors passing through Ace Data Cloud use the standard gateway envelope:
+
+```json
+{
+  "error": {
+    "code": "invalid_token",
+    "message": "Invalid token"
+  },
+  "trace_id": "2cf86e86-22a4-46e1-ac2f-032c0f2a4e89"
+}
+```
+
+Use the HTTP status and `trace_id` in retry, diagnostics, and support flows.
+
+## Related API
+
+Create or iterate on videos with the [Maestro Videos API guide](maestro_videos_api_integration_guide.md).

--- a/maestro/docs/maestro_videos_api_integration_guide.md
+++ b/maestro/docs/maestro_videos_api_integration_guide.md
@@ -1,0 +1,204 @@
+# Maestro Videos API Integration Guide
+
+`POST https://api.acedata.cloud/maestro/videos`
+
+The Maestro Videos API accepts a production brief and creates an asynchronous video job. A headless AI director plans the content, generates or selects media, produces voiceover and music, edits, captions, checks, and renders the finished video.
+
+The endpoint returns a `task_id` immediately. Retrieve progress and final output with `POST /maestro/tasks` or provide a `callback_url` for terminal-state delivery.
+
+## Authentication
+
+Create an API token in the [Ace Data Cloud console](https://platform.acedata.cloud/console/applications). Send it as a Bearer token:
+
+```http
+Authorization: Bearer YOUR_API_TOKEN
+Content-Type: application/json
+Accept: application/json
+```
+
+Keep tokens outside source control and never expose them in client-side code or logs.
+
+## Request Body
+
+| Field | Type | Required | Default | Description |
+|---|---|---:|---|---|
+| `prompt` | string | yes | - | Natural-language brief covering the subject, audience, content, tone, and desired result |
+| `action` | string | no | `generate` | `generate`, `remix`, `edit`, or `extend` |
+| `ref_task_id` | string | conditional | - | Required when `action` is `remix`, `edit`, or `extend` |
+| `file_urls` | string[] | no | - | Public image, video, or audio references |
+| `langs` | string[] | no | `["zh-cn"]` | Output language codes; the first item is primary |
+| `aspect` | string | no | `9:16` | `9:16`, `16:9`, or `1:1` |
+| `duration` | integer | no | `30` | Target length in seconds, from 1 through 600 |
+| `quality` | string | no | `standard` | `draft`, `standard`, or `premium` |
+| `scenario` | string | no | `auto` | `auto`, `narrated`, `drama`, `avatar`, `motion`, or `slideshow` |
+| `style` | string | no | `auto` | Named preset or freeform visual-style hint |
+| `voice` | string | no | `auto` | Voice preset or a 32-hex-character Fish reference ID |
+| `callback_url` | string | no | - | Public webhook URL called when the task reaches a terminal state |
+
+### Actions
+
+- `generate`: produce a new video.
+- `remix`: reinterpret an earlier video while retaining it as creative context.
+- `edit`: apply targeted changes to an earlier video.
+- `extend`: continue or lengthen an earlier video.
+
+Every non-`generate` action requires `ref_task_id` and creates a new task ID.
+
+### Quality Tiers
+
+- `draft`: faster rough cut for validating direction.
+- `standard`: balanced default.
+- `premium`: more detailed production with a higher quality multiplier and longer turnaround.
+
+### Scenarios
+
+- `auto`: let the director choose from the brief.
+- `narrated`: multi-scene explainer, documentary, brand, history, or product video.
+- `drama`: character and dialogue-driven short drama.
+- `avatar`: talking-head or digital-human production. Supply a usable portrait in `file_urls`.
+- `motion`: kinetic type, data, logo, or abstract motion graphics.
+- `slideshow`: presentation, pitch, or slide-led production.
+
+### Styles and Voices
+
+Named style presets include `cinematic`, `glass`, `luxury`, `swiss`, `modern`, `editorial`, `warm`, `vibrant`, `neon`, `mono`, `pastel`, `bold`, `industrial`, `futuristic`, and `retro`. A freeform style string is also accepted as a soft direction.
+
+Voice presets include:
+
+- `auto`
+- `warm-female`, `bright-female`, `anchor-female`, `clean-female`
+- `calm-male`, `deep-male`, `documentary-male`, `energetic-male`, `storyteller-male`
+
+Voice controls timbre, not language. One preset can speak each language in `langs`. Advanced callers may pass a 32-hex-character Fish `reference_id` instead of a preset.
+
+## Create a Video
+
+```bash
+curl --request POST 'https://api.acedata.cloud/maestro/videos' \
+  --header 'Authorization: Bearer YOUR_API_TOKEN' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "prompt": "Create a concise product launch video for first-time customers. Show the camera body and close with a clear call to action.",
+    "file_urls": [
+      "https://example.com/product.jpg",
+      "https://example.com/logo.png"
+    ],
+    "langs": ["en", "de"],
+    "aspect": "16:9",
+    "duration": 45,
+    "quality": "premium",
+    "scenario": "narrated",
+    "style": "editorial",
+    "voice": "documentary-male"
+  }'
+```
+
+Python example:
+
+```python
+import os
+
+import requests
+
+response = requests.post(
+    "https://api.acedata.cloud/maestro/videos",
+    headers={
+        "Authorization": f"Bearer {os.environ['ACEDATACLOUD_API_TOKEN']}",
+        "Content-Type": "application/json",
+    },
+    json={
+        "prompt": "Create a concise product launch video for first-time customers.",
+        "file_urls": ["https://example.com/product.jpg"],
+        "langs": ["en", "de"],
+        "aspect": "16:9",
+        "duration": 45,
+        "quality": "premium",
+        "scenario": "narrated",
+        "style": "editorial",
+    },
+    timeout=30,
+)
+response.raise_for_status()
+print(response.json())
+```
+
+Accepted response shape:
+
+```json
+{
+  "success": true,
+  "task_id": "f57e99c4-f60f-4373-a155-17742ce2357d",
+  "trace_id": "70e1cb12-c619-4292-a416-90191205996b"
+}
+```
+
+- `task_id`: UUID used with `POST /maestro/tasks`.
+- `trace_id`: request trace identifier for diagnostics and support.
+
+An accepted task is not a completed video. Poll the returned task ID before presenting an output URL.
+
+## Reference Media
+
+`file_urls` accepts public image, video, and audio URLs. Typical uses include product photos, logos, portrait references, source footage, and reference audio. Local paths are not accessible to the service; upload local files to public storage first.
+
+## Multilingual Production
+
+Pass several language codes in `langs`:
+
+```json
+{
+  "prompt": "Explain the three main benefits of our customer-support product.",
+  "langs": ["zh-cn", "en", "ja"],
+  "aspect": "16:9",
+  "duration": 30
+}
+```
+
+Successful output is represented by delivered items in `response.data.variants`. Inspect the actual variants instead of assuming every requested language was produced.
+
+## Remix, Edit, or Extend
+
+```bash
+curl --request POST 'https://api.acedata.cloud/maestro/videos' \
+  --header 'Authorization: Bearer YOUR_API_TOKEN' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "action": "edit",
+    "ref_task_id": "f57e99c4-f60f-4373-a155-17742ce2357d",
+    "prompt": "Keep the structure and visuals. Tighten the opening and use a warmer narrator."
+  }'
+```
+
+The response contains a new `task_id`. Retrieve that new task for the revised output; the source task remains unchanged.
+
+## Billing
+
+Maestro settles a successful job after production based on the actual video duration, quality, scenario, and language variants delivered. Failed tasks are not charged, and polling `POST /maestro/tasks` is free. Consult [live Maestro pricing](https://platform.acedata.cloud/services/maestro?tab=pricing) before estimating cost.
+
+## Errors
+
+Field validation is performed by the Maestro service. A missing `prompt`, an invalid `action`, a `remix`/`edit`/`extend` without `ref_task_id`, a non-list `file_urls`, or an invalid `quality` or `voice` returns HTTP 400 with a plain `detail` message:
+
+```json
+{
+  "detail": "missing field: prompt"
+}
+```
+
+Gateway-level rejections (authentication, balance, rate limiting, infrastructure) use the standard envelope instead:
+
+```json
+{
+  "error": {
+    "code": "bad_request",
+    "message": "Request validation failed"
+  },
+  "trace_id": "2cf86e86-22a4-46e1-ac2f-032c0f2a4e89"
+}
+```
+
+Relevant gateway codes include `bad_request`, `no_token`, `invalid_token`, `token_expired`, `token_mismatched`, `used_up`, `forbidden`, `too_many_requests`, `api_error`, and `timeout`. Use the HTTP status and `trace_id` when handling or reporting failures.
+
+## Next Step
+
+Use the [Maestro Tasks API guide](maestro_tasks_api_integration_guide.md) to retrieve progress and finished variants.

--- a/sync.yaml
+++ b/sync.yaml
@@ -4,6 +4,11 @@ mappings:
     exclude:
       - .github
       - .gitbooks
+  maestro:
+    repo: AceDataCloud/MaestroAPI
+    exclude:
+      - .github
+      - .gitbooks
   suno:
     repo: AceDataCloud/SunoAPI
     exclude:


### PR DESCRIPTION
## What

Adds the standalone **Maestro API documentation** package (`APIs/maestro/`), matching the structure of the other per-service docs repos (`luma`, `seedance`, …).

Maestro is the agent-native, end-to-end video production API: one natural-language brief becomes a scripted, voiced, edited, captioned, rendered video (optionally multilingual).

### Files

- `maestro/README.md` — overview, quick start, async workflow diagram, APIs & guides table
- `maestro/docs/maestro_videos_api_integration_guide.md` — `POST /maestro/videos`: fields, actions, quality/scenario/style/voice, reference media, multilingual, remix/edit/extend, billing, errors
- `maestro/docs/maestro_tasks_api_integration_guide.md` — `POST /maestro/tasks`: single-task retrieve, task shape, polling, `retrieve_batch` history, errors
- Registration: `sync.yaml` (`maestro → AceDataCloud/MaestroAPI`) + root `README.md`

### Grounding

Every documented field/enum/default/min-max was cross-checked against the live source of truth (no fabrication):

- `openapi/…videos` and `openapi/…tasks` on `PlatformBackend@main`
- `maestro/worker/server.py` validation on `PlatformService@main`
- The official `development_maestro_videos.md` / `development_maestro_tasks.md` guides (billing, `+6`/extra language, quality/scenario multipliers, status lifecycle)

Automated checks: all local links resolve, all 12 OpenAPI request fields + both endpoints + history controls + terminal states are covered, and a fabrication scan (invented error codes, HMAC/retention/QPS, dollar amounts) is clean.

> **Post-merge prerequisite:** create the `AceDataCloud/MaestroAPI` sub-repo before the `Sync to Sub-Repos` job runs.

## 🤖 对抗评审 (reviewer: claude-subagent, 1 round)

- **RISK: videos guide only showed the gateway `bad_request` envelope for field validation** → 已修. The worker raises `HTTPException(400, detail=...)` for the common client errors (missing `prompt`, bad `action`, missing `ref_task_id`, non-list `file_urls`, bad `quality`/`voice`), so callers actually get `{"detail": "..."}` — same shape as the 404 the tasks guide already documents. The Errors section now documents the worker `{detail}` 400 and scopes the `{error:{code},trace_id}` envelope to gateway-level rejections.
- NIT: `retrieve_batch` `count` described as "total matching" → 已修. The worker's `count_for_user` ignores the `created_at_*` window, so wording changed to "total task count, independent of `created_at_*`".
- NIT: illustrative task shape had `progress.message` set while `data.progress` was `[]` (self-contradictory, since `message` derives from the last progress event) → 已修 (added the matching event).
- NIT: "32-character" vs worker's 32-hex reference id → 已修 ("32-hex-character").

Everything else (enums, defaults, min/max, `_public()` response shape, gateway error-code set, `{detail}` 404, billing, links, `sync.yaml`, README row) was confirmed accurate against the sources.
