### PR TITLE
feat(happyhorse): add Happy Horse video API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Monorepo for all AceDataCloud API documentation repositories.
 | `sora/` | [SoraAPI](https://github.com/AceDataCloud/SoraAPI) | Sora video generation API docs |
 | `veo/` | [VeoAPI](https://github.com/AceDataCloud/VeoAPI) | Veo video generation API docs |
 | `flux/` | [FluxAPI](https://github.com/AceDataCloud/FluxAPI) | Flux image generation API docs |
+| `happyhorse/` | [HappyHorseAPI](https://github.com/AceDataCloud/HappyHorseAPI) | Happy Horse video generation and editing API docs |
 | `serp/` | [SerpAPI](https://github.com/AceDataCloud/SerpAPI) | Web search API docs |
 | `nanobanana/` | [NanoBananaAPI](https://github.com/AceDataCloud/NanoBananaAPI) | NanoBanana image generation API docs |
 | `openai/` | [OpenAIAPI](https://github.com/AceDataCloud/OpenAIAPI) | OpenAI-compatible API docs |

--- a/happyhorse/README.md
+++ b/happyhorse/README.md
@@ -1,0 +1,85 @@
+# Happy Horse Video API
+
+Generate and edit AI videos with Happy Horse through one Ace Data Cloud API.
+
+![Platform](https://img.shields.io/badge/platform-Ace%20Data%20Cloud-0f766e?style=flat-square) ![API](https://img.shields.io/badge/type-AI%20Video%20API-2563eb?style=flat-square) ![Docs](https://img.shields.io/badge/docs-online-16a34a?style=flat-square)
+
+API home page: [Ace Data Cloud - Happy Horse Video](https://platform.acedata.cloud/service/happyhorse)
+
+Keywords: happy-horse-api, happyhorse-api, ai-video, video-generation, video-editing,
+text-to-video, image-to-video, reference-to-video, rest-api, ai-api, Ace Data Cloud
+
+## Why Use Happy Horse on Ace Data Cloud
+
+- One endpoint for text, first-frame image, reference-image, and video-edit workflows
+- Unified API key, billing, usage records, and task tracking
+- 720P and 1080P output with 3-15 second generation
+- Asynchronous polling and webhook callbacks for long-running jobs
+- CDN-backed final video URLs
+
+## Overview
+
+`POST /happyhorse/videos` dispatches four workflows through the `action` field:
+
+| Action | Models | Required input |
+|---|---|---|
+| `generate` | `happyhorse-1.0-t2v`, `happyhorse-1.1-t2v` | `prompt` |
+| `image_to_video` | `happyhorse-1.0-i2v`, `happyhorse-1.1-i2v` | `image_url` |
+| `reference_to_video` | `happyhorse-1.0-r2v`, `happyhorse-1.1-r2v` | `prompt`, 1-9 `image_urls` |
+| `video_edit` | `happyhorse-1.0-video-edit` | `prompt`, `video_url` |
+
+`POST /happyhorse/tasks` retrieves one or several asynchronous tasks.
+
+## Quick Start
+
+- Base URL: [https://api.acedata.cloud](https://api.acedata.cloud)
+- Service page: [Happy Horse Video on Ace Data Cloud](https://platform.acedata.cloud/service/happyhorse)
+- Developer docs: [docs.acedata.cloud](https://docs.acedata.cloud)
+
+```bash
+curl --request POST "https://api.acedata.cloud/happyhorse/videos" \
+  --header "Authorization: Bearer YOUR_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "action": "generate",
+    "model": "happyhorse-1.1-t2v",
+    "prompt": "A cinematic white horse crossing a snowy ridge at sunrise, slow camera push",
+    "resolution": "720P",
+    "ratio": "16:9",
+    "duration": 5,
+    "async": true
+  }'
+```
+
+Poll the returned task ID:
+
+```bash
+curl --request POST "https://api.acedata.cloud/happyhorse/tasks" \
+  --header "Authorization: Bearer YOUR_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{"id": "TASK_ID", "action": "retrieve"}'
+```
+
+## APIs and Guides
+
+| API | Path | Integration guide |
+|---|---|---|
+| [Happy Horse Videos API](https://platform.acedata.cloud/documents/happyhorse-videos) | `/happyhorse/videos` | [Videos API Integration Guide](docs/happyhorse_videos_api_integration_guide.md) |
+| [Happy Horse Tasks API](https://platform.acedata.cloud/documents/happyhorse-tasks) | `/happyhorse/tasks` | [Tasks API Integration Guide](docs/happyhorse_tasks_api_integration_guide.md) |
+
+## Agent Integrations
+
+- MCP package: [`mcp-happyhorse`](https://pypi.org/project/mcp-happyhorse/)
+- Hosted MCP: `https://happyhorse.mcp.acedata.cloud/mcp`
+- Agent Skill: [`happyhorse-video`](https://github.com/AceDataCloud/Skills/tree/main/skills/happyhorse-video)
+
+## Related Resources
+
+- [Ace Data Cloud Developer Platform](https://platform.acedata.cloud)
+- [API Documentation](https://docs.acedata.cloud)
+- [Status Page](https://status.acedata.cloud)
+- [Ace Data Cloud GitHub Organization](https://github.com/AceDataCloud)
+
+## Support
+
+For support, visit [platform.acedata.cloud/support](https://platform.acedata.cloud/support).

--- a/happyhorse/docs/happyhorse_tasks_api_integration_guide.md
+++ b/happyhorse/docs/happyhorse_tasks_api_integration_guide.md
@@ -1,0 +1,147 @@
+# Happy Horse Tasks API Integration Guide
+
+Use the Happy Horse Tasks API to retrieve video generation and editing jobs submitted through
+`POST /happyhorse/videos`.
+
+## Endpoint
+
+```text
+POST https://api.acedata.cloud/happyhorse/tasks
+```
+
+```http
+Authorization: Bearer YOUR_API_KEY
+Content-Type: application/json
+```
+
+## Retrieve One Task
+
+```bash
+curl --request POST "https://api.acedata.cloud/happyhorse/tasks" \
+  --header "Authorization: Bearer YOUR_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "id": "b8976e18-32dc-4718-9ed8-1ea090fcb6ea",
+    "action": "retrieve"
+  }'
+```
+
+`action` defaults to `retrieve`, but sending it explicitly makes the request unambiguous.
+
+## Single-Task Response
+
+The task record preserves both the original video request and its current or final response:
+
+```json
+{
+  "id": "b8976e18-32dc-4718-9ed8-1ea090fcb6ea",
+  "request": {
+    "action": "generate",
+    "model": "happyhorse-1.1-t2v",
+    "prompt": "A cinematic shot of a white horse running across a moonlit beach",
+    "resolution": "720P",
+    "duration": 5
+  },
+  "type": "videos",
+  "response": {
+    "success": true,
+    "task_id": "b8976e18-32dc-4718-9ed8-1ea090fcb6ea",
+    "trace_id": "fb751e1e-4705-49ea-9fd4-5024b7865ea2",
+    "data": [
+      {
+        "id": "1469cfc3-3004-4d9e-ab10-xxxxxx",
+        "video_url": "https://cdn.acedata.cloud/happyhorse/c8cbf53aa0.mp4",
+        "state": "succeeded",
+        "duration": 5,
+        "resolution": "720P",
+        "ratio": "16:9"
+      }
+    ]
+  }
+}
+```
+
+Important fields:
+
+| Field | Meaning |
+|---|---|
+| `id` | Ace Data Cloud task ID |
+| `request` | Original `/happyhorse/videos` request body |
+| `response` | Current or final Videos API response |
+| `response.data[].state` | `pending`, `succeeded`, or `error` |
+| `response.data[].video_url` | Final CDN URL when successful |
+| `response.trace_id` | Trace ID for support and debugging |
+
+If `response` or its final `video_url` is not available yet, wait about 15 seconds and query the
+same task again. Stop polling on a final video URL or terminal error.
+
+## Retrieve Multiple Tasks
+
+Set `action` to `retrieve_batch` and pass the IDs array:
+
+```bash
+curl --request POST "https://api.acedata.cloud/happyhorse/tasks" \
+  --header "Authorization: Bearer YOUR_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "ids": [
+      "b8976e18-32dc-4718-9ed8-1ea090fcb6ea",
+      "27837f92-d1c1-4db4-ad9a-4e6e81d9f6c1"
+    ],
+    "action": "retrieve_batch"
+  }'
+```
+
+The response contains:
+
+```json
+{
+  "items": [],
+  "count": 0
+}
+```
+
+`items` contains matching task records in the same shape as the single-task response. `count` is
+the number of matching records.
+
+## Python Polling Example
+
+```python
+import time
+
+import requests
+
+task_id = "YOUR_TASK_ID"
+headers = {
+    "Authorization": "Bearer YOUR_API_KEY",
+    "Content-Type": "application/json",
+}
+
+for _ in range(100):
+    task = requests.post(
+        "https://api.acedata.cloud/happyhorse/tasks",
+        headers=headers,
+        json={"id": task_id, "action": "retrieve"},
+        timeout=30,
+    ).json()
+    response = task.get("response") or {}
+    videos = response.get("data") or []
+    if videos and videos[0].get("video_url"):
+        print(videos[0]["video_url"])
+        break
+    if videos and videos[0].get("state") == "error":
+        raise RuntimeError(response)
+    time.sleep(15)
+else:
+    raise TimeoutError(f"Task {task_id} did not finish in time")
+```
+
+## Errors
+
+| Status | Meaning |
+|---|---|
+| `400` | Missing IDs or invalid action |
+| `401` | Missing or invalid API token |
+| `500` | Internal task lookup failure |
+
+Use the same token that submitted the video task.

--- a/happyhorse/docs/happyhorse_videos_api_integration_guide.md
+++ b/happyhorse/docs/happyhorse_videos_api_integration_guide.md
@@ -1,0 +1,181 @@
+# Happy Horse Videos API Integration Guide
+
+The Happy Horse Videos API supports text-to-video, first-frame image-to-video,
+reference-image-to-video, and video editing through one endpoint.
+
+## Endpoint
+
+```text
+POST https://api.acedata.cloud/happyhorse/videos
+```
+
+Authenticate every request with an Ace Data Cloud API token:
+
+```http
+Authorization: Bearer YOUR_API_KEY
+Content-Type: application/json
+```
+
+Create a token in the [Ace Data Cloud console](https://platform.acedata.cloud/console/credentials).
+
+## Actions and Models
+
+| Action | Models | Required fields |
+|---|---|---|
+| `generate` | `happyhorse-1.0-t2v`, `happyhorse-1.1-t2v` | `prompt` |
+| `image_to_video` | `happyhorse-1.0-i2v`, `happyhorse-1.1-i2v` | `image_url` |
+| `reference_to_video` | `happyhorse-1.0-r2v`, `happyhorse-1.1-r2v` | `prompt`, `image_urls` |
+| `video_edit` | `happyhorse-1.0-video-edit` | `prompt`, `video_url` |
+
+If `model` is omitted, each action uses its latest available model. The default action is
+`generate`.
+
+## Request Fields
+
+| Field | Type | Values and behavior |
+|---|---|---|
+| `action` | string | `generate`, `image_to_video`, `reference_to_video`, `video_edit` |
+| `model` | string | Must belong to the selected action's model family |
+| `prompt` | string | Required for text, reference, and edit actions; optional for image-to-video |
+| `image_url` | string | First-frame URL for image-to-video |
+| `image_urls` | string[] | 1-9 references for reference-to-video; 0-5 for editing |
+| `video_url` | string | Source video URL for editing |
+| `resolution` | string | `720P` or `1080P`; default `1080P` |
+| `ratio` | string | `16:9`, `9:16`, `1:1`, `4:3`, `3:4`; text/reference actions only |
+| `duration` | integer | 3-15 seconds; text/image/reference actions only; default 5 |
+| `watermark` | boolean | Add the Happy Horse watermark; default `false` |
+| `audio_setting` | string | `auto` or `origin`; video editing only |
+| `seed` | integer | 0-2147483647 |
+| `callback_url` | string | Webhook URL for asynchronous delivery |
+| `async` | boolean | Return a task ID immediately for polling |
+
+Resolution uses an uppercase `P`. Image-to-video derives its ratio from the first-frame image.
+Video editing derives duration and ratio from the source video.
+
+## Text-to-Video
+
+```bash
+curl --request POST "https://api.acedata.cloud/happyhorse/videos" \
+  --header "Authorization: Bearer YOUR_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "action": "generate",
+    "model": "happyhorse-1.1-t2v",
+    "prompt": "A cinematic white horse lifts its head, its mane moving in the sunrise wind, slow camera push",
+    "resolution": "720P",
+    "ratio": "16:9",
+    "duration": 5
+  }'
+```
+
+## First-Frame Image-to-Video
+
+```bash
+curl --request POST "https://api.acedata.cloud/happyhorse/videos" \
+  --header "Authorization: Bearer YOUR_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "action": "image_to_video",
+    "model": "happyhorse-1.1-i2v",
+    "image_url": "https://cdn.acedata.cloud/b1c82e4937.png",
+    "prompt": "The horse lifts its head while the mane moves in the wind, gentle camera push",
+    "resolution": "1080P",
+    "duration": 5
+  }'
+```
+
+The prompt is optional. Do not pass `ratio`; the service follows the input image.
+
+## Reference-to-Video
+
+Pass 1-9 reference images. In the prompt, `character1`, `character2`, and later names refer to the
+images in array order.
+
+```bash
+curl --request POST "https://api.acedata.cloud/happyhorse/videos" \
+  --header "Authorization: Bearer YOUR_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "action": "reference_to_video",
+    "model": "happyhorse-1.1-r2v",
+    "prompt": "character1 walks through a sunrise meadow with the warm leather and gold style from character2",
+    "image_urls": [
+      "https://cdn.acedata.cloud/b1c82e4937.png",
+      "https://cdn.acedata.cloud/eb75d88a3f.png"
+    ],
+    "resolution": "720P",
+    "ratio": "16:9",
+    "duration": 5
+  }'
+```
+
+## Video Editing
+
+Pass the source video, editing instructions, and optionally up to 5 references. Set
+`audio_setting` to `origin` to preserve source audio.
+
+```bash
+curl --request POST "https://api.acedata.cloud/happyhorse/videos" \
+  --header "Authorization: Bearer YOUR_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "action": "video_edit",
+    "model": "happyhorse-1.0-video-edit",
+    "prompt": "Apply the warm leather and gold style from the reference while preserving camera motion",
+    "video_url": "https://platform2.cdn.acedata.cloud/happyhorse/27837f92-d1c1-4db4-ad9a-4e6e81d9f6c1.mp4",
+    "image_urls": ["https://cdn.acedata.cloud/eb75d88a3f.png"],
+    "resolution": "720P",
+    "audio_setting": "origin"
+  }'
+```
+
+Do not pass `duration` or `ratio` for editing; those fields are derived from the source video.
+
+## Synchronous Response
+
+Without `async` or `callback_url`, the request waits for completion and returns the final video:
+
+```json
+{
+  "success": true,
+  "task_id": "27837f92-d1c1-4db4-ad9a-4e6e81d9f6c1",
+  "trace_id": "6071ab5e-2f37-46f0-9e07-f1e378112e69",
+  "data": [
+    {
+      "id": "9650580f-6d9e-4bc1-823a-29011790c5cb",
+      "video_url": "https://platform2.cdn.acedata.cloud/happyhorse/27837f92-d1c1-4db4-ad9a-4e6e81d9f6c1.mp4",
+      "state": "succeeded",
+      "duration": 5,
+      "resolution": "720P",
+      "ratio": null
+    }
+  ]
+}
+```
+
+`task_id` is the Ace Data Cloud task ID. `data[].id` is the upstream Happy Horse task ID. Use
+`trace_id` when contacting support.
+
+## Asynchronous Processing
+
+Set `"async": true` to return immediately:
+
+```json
+{"task_id": "b8976e18-32dc-4718-9ed8-1ea090fcb6ea"}
+```
+
+Poll it through the [Tasks API](happyhorse_tasks_api_integration_guide.md). Alternatively, provide
+`callback_url`; the service posts the final response to that URL.
+
+## Errors
+
+| Status | Meaning |
+|---|---|
+| `400` | Missing field, invalid action/model pairing, out-of-range duration, or too many images |
+| `401` | Missing or invalid API token |
+| `403` | Insufficient balance or content moderation rejection |
+| `429` | Upstream rate limit; retry with backoff |
+| `500` | Upstream generation or internal service failure |
+
+Failed generation tasks are not billed. For video editing, billing duration is based on the
+upstream-reported input plus output duration rather than a request field.

--- a/sync.yaml
+++ b/sync.yaml
@@ -90,6 +90,11 @@ mappings:
     exclude:
       - .github
       - .gitbooks
+  happyhorse:
+    repo: AceDataCloud/HappyHorseAPI
+    exclude:
+      - .github
+      - .gitbooks
   claude:
     repo: AceDataCloud/ClaudeAPI
     exclude:


### PR DESCRIPTION
## Summary

Add the **Happy Horse Video** API documentation repo entry, mirroring the existing API docs (seedance / wan). Content is sourced from the live platform docs, OpenAPI spec, and the `PlatformService/ttapi` worker — not fabricated.

- `happyhorse/README.md` — service overview, action/model table, quick start, links to the two guides and the paired MCP/skill
- `docs/happyhorse_videos_api_integration_guide.md` — all four workflows (text / first-frame image / reference / edit), full field reference, sync + async + callback responses, error table
- `docs/happyhorse_tasks_api_integration_guide.md` — single + batch retrieval, response shape, a Python polling example, error table
- Registered in `README.md` and `sync.yaml` → `AceDataCloud/HappyHorseAPI`

Key correctness points documented explicitly: `ratio` applies only to text/reference generation, `duration` (3–15) does not apply to editing, `audio_setting` applies only to editing, resolution uses uppercase `720P`/`1080P`.

## Validation

- `sync.yaml` mapping present; README covers both `/happyhorse/videos` and `/happyhorse/tasks`
- All Markdown code fences balanced; every relative doc link resolves
- All 4 JSON examples parse as valid JSON

## 🤖 对抗评审 (reviewer: codex `gpt-5.4`, 1 round)

Docs-only. Request/response examples validated as parseable JSON and cross-checked against the OpenAPI spec + worker payload construction. `VERDICT: CLEAN`
