### PR TITLE
docs(kimi): recommend Kimi K3

### DIFF
--- a/kimi/README.md
+++ b/kimi/README.md
@@ -4,9 +4,9 @@ Moonshot AI Kimi generative services, including chat completions.
 
 ![Platform](https://img.shields.io/badge/platform-Ace%20Data%20Cloud-0f766e?style=flat-square) ![API](https://img.shields.io/badge/type-AI%20API-2563eb?style=flat-square) ![Docs](https://img.shields.io/badge/docs-online-16a34a?style=flat-square)
 
-API home page: [Ace Data Cloud - Kimi](https://platform.acedata.cloud/service/kimi)
+API home page: [Ace Data Cloud - Kimi](https://platform.acedata.cloud/services/kimi)
 
-Keywords: kimi-api, moonshot-ai, kimi-k2, chat-completions, rest-api, ai-api, developer-tools, AI API, REST API, Developer API, Ace Data Cloud
+Keywords: kimi-api, moonshot-ai, kimi-k3, kimi-k2, chat-completions, rest-api, ai-api, developer-tools, AI API, REST API, Developer API, Ace Data Cloud
 
 ## Why Use Kimi on Ace Data Cloud
 
@@ -17,18 +17,18 @@ Keywords: kimi-api, moonshot-ai, kimi-k2, chat-completions, rest-api, ai-api, de
 
 ## Overview
 
-Kimi is Moonshot AI's powerful AI dialogue system featuring strong reasoning capabilities and the ability to handle extended contexts. The Kimi K2.5 series supports multi-turn conversations, streaming responses, and advanced reasoning with thought processes visible to users.
+Kimi is Moonshot AI's powerful AI dialogue system. The current flagship, `kimi-k3`, supports reasoning, vision, tool calling, a 1,048,576-token context window, and up to 16,384 output tokens. Kimi K2 models remain available for compatibility with existing applications.
 
 ## Application Process
 
-To use the Kimi API, apply for the corresponding service on the [Kimi Chat Completion API](https://platform.acedata.cloud/documents/b23bbfa3-c820-47ee-b307-6c6dedc9d0cf) page. After entering the page, click the "Acquire" button.
+To use the Kimi API, apply for the corresponding service on the [Kimi Chat Completion API](https://platform.acedata.cloud/documents/kimi-chat-completions) page. After entering the page, click the "Acquire" button.
 
 There is a free quota available for first-time applicants, allowing you to use this API for free.
 
 ## Quick Start
 
 - Base URL: [https://api.acedata.cloud](https://api.acedata.cloud)
-- Service page: [Kimi on Ace Data Cloud](https://platform.acedata.cloud/service/kimi)
+- Service page: [Kimi on Ace Data Cloud](https://platform.acedata.cloud/services/kimi)
 - Docs: [Developer documentation](https://docs.acedata.cloud)
 
 ```bash
@@ -36,7 +36,7 @@ curl --request POST "https://api.acedata.cloud/kimi/chat/completions" \
   --header "Authorization: Bearer YOUR_API_KEY" \
   --header "Content-Type: application/json" \
   --data '{
-    "model": "kimi-k2.5",
+    "model": "kimi-k3",
     "messages": [{"role": "user", "content": "Hello!"}]
   }'
 ```
@@ -47,4 +47,4 @@ Explore the supported endpoints and integration guides for Kimi.
 
 | API | Path | Integration Guidance |
 | ---- | ---- | ------------ |
-| [Kimi Chat Completion API](https://platform.acedata.cloud/documents/b23bbfa3-c820-47ee-b307-6c6dedc9d0cf) | `/kimi/chat/completions` | [Kimi Chat Completion API Integration Guide](docs/kimi_chat_completions_api_integration_guide.md) |
+| [Kimi Chat Completion API](https://platform.acedata.cloud/documents/kimi-chat-completions) | `/kimi/chat/completions` | [Kimi Chat Completion API Integration Guide](docs/kimi_chat_completions_api_integration_guide.md) |

--- a/kimi/docs/kimi_chat_completions_api_integration_guide.md
+++ b/kimi/docs/kimi_chat_completions_api_integration_guide.md
@@ -4,9 +4,11 @@ Kimi is a very powerful AI dialogue system that can generate smooth and natural 
 
 This document mainly introduces the usage process of the Kimi Chat Completion API, allowing us to easily utilize the official Kimi dialogue features.
 
+The recommended model is `kimi-k3`, which supports reasoning, vision, tool calling, a 1,048,576-token context window, and up to 16,384 output tokens. Kimi K2 models remain available for compatibility.
+
 ## Application Process
 
-To use the Kimi Chat Completion API, you can first visit the [Kimi Chat Completion API](https://platform.acedata.cloud/documents/b23bbfa3-c820-47ee-b307-6c6dedc9d0cf) page and click the "Acquire" button to obtain the credentials needed for the request:
+To use the Kimi Chat Completion API, you can first visit the [Kimi Chat Completion API](https://platform.acedata.cloud/documents/kimi-chat-completions) page and click the "Acquire" button to obtain the credentials needed for the request:
 
 ![](https://cdn.acedata.cloud/nyq0xz.png)
 
@@ -20,13 +22,13 @@ Next, you can fill in the corresponding content on the interface, as shown in th
 
 <p><img src="https://cdn.acedata.cloud/ej5ozg.png" width="400" class="m-auto"></p>
 
-When using this interface for the first time, we need to fill in at least three pieces of content: one is `authorization`, which can be selected directly from the dropdown list. The other parameter is `model`, which is the category of the Kimi official model we choose to use. Here we mainly have 7 types of models; details can be found in the models we provide. The last parameter is `messages`, which is an array of our input questions. It is an array that allows multiple questions to be uploaded simultaneously, with each question containing `role` and `content`. The `role` indicates the role of the questioner, and we provide three identities: `user`, `assistant`, and `system`. The other `content` is the specific content of our question.
+When using this interface for the first time, we need to fill in at least three pieces of content: one is `authorization`, which can be selected directly from the dropdown list. The other parameter is `model`; use `kimi-k3` for the current flagship or select a compatible K2 model. The last parameter is `messages`, which is an array of our input questions. It is an array that allows multiple questions to be uploaded simultaneously, with each question containing `role` and `content`. The `role` indicates the role of the questioner, and we provide three identities: `user`, `assistant`, and `system`. The other `content` is the specific content of our question.
 
 You can also notice that there is corresponding code generation on the right side; you can copy the code to run directly or click the "Try" button for testing.
 
 <p><img src="https://cdn.acedata.cloud/six7e3.png" width="400" class="m-auto"></p>
 
-After the call, we find that the returned result is as follows:
+The following response snapshot was captured from a K2.5 request and is retained to illustrate the response structure. When you use the K3 examples below, the response `model` field will be `kimi-k3` and the generated content will reflect K3:
 
 ```json
 {
@@ -98,7 +100,7 @@ headers = {
 }
 
 payload = {
-    "model": "kimi-k2.5",
+    "model": "kimi-k3",
     "messages": [{"role":"user","content":"Hello"}],
     "stream": True
 }
@@ -118,7 +120,7 @@ const options = {
     "content-type": "application/json"
   },
   body: JSON.stringify({
-    "model": "kimi-k2.5",
+    "model": "kimi-k3",
     "messages": [{"role":"user","content":"Hello"}],
     "stream": true
   })
@@ -134,7 +136,7 @@ Java sample code:
 
 ```java
 JSONObject jsonObject = new JSONObject();
-jsonObject.put("model", "kimi-k2.5");
+jsonObject.put("model", "kimi-k3");
 jsonObject.put("messages", [{"role":"user","content":"Hello"}]);
 jsonObject.put("stream", true);
 MediaType mediaType = "application/json; charset=utf-8".toMediaType();
@@ -174,7 +176,7 @@ headers = {
 }
 
 payload = {
-    "model": "kimi-k2.5",
+    "model": "kimi-k3",
     "messages": [{"role":"assistant","content":"Hello! How can I help you today?"},{"role":"user","content":"What model are you?"}]
 }
 
@@ -182,7 +184,7 @@ response = requests.post(url, json=payload, headers=headers)
 print(response.text)
 ```
 
-By uploading multiple query words, you can easily achieve multi-turn dialogue and receive responses like the following:
+By uploading multiple query words, you can easily achieve multi-turn dialogue. The following retained K2.5 snapshot illustrates the response structure; a K3 request returns `model: kimi-k3` and K3-generated content:
 
 ```json
 {


### PR DESCRIPTION
## Summary

- update the Kimi API README and English integration guide for `kimi-k3`
- document reasoning, vision, tool calling, 1,048,576-token context, and 16,384-token output
- switch request examples to K3 while explicitly preserving historical K2.5 snapshots as response-shape references
- replace UUID/singular routes with canonical human-facing Kimi links

## Validation

- canonical service and document links return HTTP 200
- stale UUID/singular links absent
- all request examples use `kimi-k3`
- historical K2.5 snapshots explicitly state K3 returns `model: kimi-k3`
- `git diff --check` -> passed

## 🤖 对抗评审

- RISK: K2.5 snapshots could confuse K3 users -> fixed with explicit before-each-snapshot notes
- exact model IDs, specs, links, and no-fallback semantics reviewed
- VERDICT: CLEAN
