### PR TITLE
docs(claude): add claude-opus-5 to model lineup

### DIFF
--- a/claude/README.md
+++ b/claude/README.md
@@ -6,7 +6,7 @@ Anthropic Claude generative services, including chat completions and native mess
 
 API home page: [Ace Data Cloud - Claude](https://platform.acedata.cloud/service/claude)
 
-Keywords: claude-api, anthropic, claude-fable-5, claude-opus-4-8, claude-sonnet-5, claude-chat-completions, claude-messages, rest-api, ai-api, developer-tools, AI API, REST API, Developer API, Ace Data Cloud
+Keywords: claude-api, anthropic, claude-fable-5, claude-opus-5, claude-opus-4-8, claude-sonnet-5, claude-chat-completions, claude-messages, rest-api, ai-api, developer-tools, AI API, REST API, Developer API, Ace Data Cloud
 
 ## Why Use Claude on Ace Data Cloud
 
@@ -17,7 +17,7 @@ Keywords: claude-api, anthropic, claude-fable-5, claude-opus-4-8, claude-sonnet-
 
 ## Overview
 
-Claude is Anthropic's AI assistant, offering powerful language understanding and generation. The current flagship `claude-fable-5` leads the lineup, alongside `claude-opus-4-8`, `claude-opus-4-7`, `claude-sonnet-5`, and `claude-haiku-4-5-20251001`. It supports OpenAI-compatible chat completions format as well as Anthropic's native messages API, with features including multi-turn dialogue, streaming responses, vision models, and extended thinking.
+Claude is Anthropic's AI assistant, offering powerful language understanding and generation. The current flagship `claude-fable-5` leads the lineup, alongside `claude-opus-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-sonnet-5`, and `claude-haiku-4-5-20251001`. It supports OpenAI-compatible chat completions format as well as Anthropic's native messages API, with features including multi-turn dialogue, streaming responses, vision models, and extended thinking.
 
 ## Application Process
 


### PR DESCRIPTION
## What
Add `claude-opus-5` to the Claude API discovery README (keywords + model lineup). English discovery copy only.

## 🤖 对抗评审

独立评审（Claude general-purpose subagent；Codex 本轮触发 usage limit 已回退）逐条 hunt，结论 **无计费/结构缺陷**，仅两条流程项：

- **[low] 16 个非中文 locale 的 `claudeOpus5Description` 为英文占位** — 这是 `/i18n-backfill` 的既定行为（从 `en` 播种、Nexior 禁止 `yarn translate`），与既有 backfill 一致。**接受，不改**。
- **[med] 跨仓部署顺序** — PS 的 `VISIBLE_MODELS` 若先于 Mongo 能力上线，`/v1/models` 会列出 opus-5 但调用 500。**修复=排序**：PB 计费规则 merge+sync → 插入 Mongo 能力 → 再 merge PS。计费关键路径不受影响。

已确认：5 个 service cost、2 个 api visible_models、`_chat_models.json`、4 个 openapi enum、`config/models.json`、worker VISIBLE_MODELS、Skills/APIs/MCP、Nexior(常量+对象+类型+分组+数组+i18n×18) 全部与 opus-4-8 对齐；计费为 opus-4-8 字节级克隆；`[1m]` 陷阱各处均用裸 id 规避；`pytest tests/api_cost` 963 passed。
