### PR TITLE
chore(sync): mirror the last 5 subdirs + honor per-mapping excludes

### DIFF
--- a/.github/workflows/sync-to-repos.yml
+++ b/.github/workflows/sync-to-repos.yml
@@ -116,11 +116,16 @@ jobs:
           done < "$GITHUB_WORKSPACE/sync.yaml"
 
           # Sync files: monorepo subdir -> target repo root
-          # Delete files in target that don't exist in source (except .git, .github, .gitbooks)
+          # --delete prunes files removed from the monorepo. $EXCLUDES comes from
+          # sync.yaml; the literals below also shield repo-governance files that
+          # only ever live in the target repo.
           rsync -av --delete \
             --exclude='.git' \
-            --exclude='.github' \
-            --exclude='.gitbooks' \
+            --exclude='LICENSE*' \
+            --exclude='CONTRIBUTING*' \
+            --exclude='CODE_OF_CONDUCT*' \
+            --exclude='SECURITY*' \
+            $EXCLUDES \
             "$GITHUB_WORKSPACE/${DIR}/" /tmp/target/
 
           # Check for changes

--- a/README.md
+++ b/README.md
@@ -19,7 +19,20 @@ Monorepo for all AceDataCloud API documentation repositories.
 | `wan/` | [WanAPI](https://github.com/AceDataCloud/WanAPI) | Wan (Tongyi Wanxiang) video generation API docs |
 | `seedance/` | [SeedanceAPI](https://github.com/AceDataCloud/SeedanceAPI) | Seedance (ByteDance) video generation API docs |
 | `seedream/` | [SeedreamAPI](https://github.com/AceDataCloud/SeedreamAPI) | Seedream (ByteDance) image generation API docs |
-| `aichat/` | — | AI Dialogue (multi-model chat) API docs |
+| `kling/` | [KlingAPI](https://github.com/AceDataCloud/KlingAPI) | Kling video generation API docs |
+| `hailuo/` | [HailuoAPI](https://github.com/AceDataCloud/HailuoAPI) | Hailuo video generation API docs |
+| `producer/` | [ProducerAPI](https://github.com/AceDataCloud/ProducerAPI) | Producer music generation API docs |
+| `claude/` | [ClaudeAPI](https://github.com/AceDataCloud/ClaudeAPI) | Claude chat completions API docs |
+| `gemini/` | [GeminiAPI](https://github.com/AceDataCloud/GeminiAPI) | Gemini chat completions API docs |
+| `fish/` | [FishAPI](https://github.com/AceDataCloud/FishAPI) | Fish Audio TTS and voice cloning API docs |
+| `face/` | [FaceAPI](https://github.com/AceDataCloud/FaceAPI) | Face transformation API docs |
+| `shorturl/` | [ShortURLAPI](https://github.com/AceDataCloud/ShortURLAPI) | Short URL API docs |
+| `webextrator/` | [WebExtratorAPI](https://github.com/AceDataCloud/WebExtratorAPI) | Web extraction and rendering API docs |
+| `aichat/` | [AiChatAPI](https://github.com/AceDataCloud/AiChatAPI) | AI Dialogue (multi-model chat) API docs |
+| `grok/` | [GrokAPI](https://github.com/AceDataCloud/GrokAPI) | Grok chat completions API docs |
+| `glm/` | [GlmAPI](https://github.com/AceDataCloud/GlmAPI) | GLM chat completions API docs |
+| `kimi/` | [KimiAPI](https://github.com/AceDataCloud/KimiAPI) | Kimi chat completions API docs |
+| `coze/` | [CozeAPI](https://github.com/AceDataCloud/CozeAPI) | Importable OpenAPI plugin schemas for Coze / 扣子 |
 
 ## MCP Servers
 

--- a/sync.yaml
+++ b/sync.yaml
@@ -110,3 +110,28 @@ mappings:
     exclude:
       - .github
       - .gitbooks
+  aichat:
+    repo: AceDataCloud/AiChatAPI
+    exclude:
+      - .github
+      - .gitbooks
+  grok:
+    repo: AceDataCloud/GrokAPI
+    exclude:
+      - .github
+      - .gitbooks
+  glm:
+    repo: AceDataCloud/GlmAPI
+    exclude:
+      - .github
+      - .gitbooks
+  kimi:
+    repo: AceDataCloud/KimiAPI
+    exclude:
+      - .github
+      - .gitbooks
+  coze:
+    repo: AceDataCloud/CozeAPI
+    exclude:
+      - .github
+      - .gitbooks


### PR DESCRIPTION
## 背景

`APIs/` 有 27 个子目录,但 `sync.yaml` 只映射了 22 个 —— `aichat`、`grok`、`glm`、`kimi`、`coze` 从未发布到任何独立仓库(其中 grok/glm/kimi 在 7/19–7/22 更新过,但那些工作从未对外可见)。

同时 `wan`、`fish`、`face` 三个映射早已配置,但目标仓库 **根本不存在**,导致每次定时同步必然失败:

```
remote: Repository not found.
fatal: repository 'https://github.com/AceDataCloud/FishAPI.git/' not found
```

## 本次改动

**1. 补齐镜像覆盖(22 → 27)**

已创建并用各自子目录初始化了 8 个仓库:
[WanAPI](https://github.com/AceDataCloud/WanAPI) · [FishAPI](https://github.com/AceDataCloud/FishAPI) · [FaceAPI](https://github.com/AceDataCloud/FaceAPI) · [AiChatAPI](https://github.com/AceDataCloud/AiChatAPI) · [GrokAPI](https://github.com/AceDataCloud/GrokAPI) · [GlmAPI](https://github.com/AceDataCloud/GlmAPI) · [KimiAPI](https://github.com/AceDataCloud/KimiAPI) · [CozeAPI](https://github.com/AceDataCloud/CozeAPI)

创建后重跑 `Sync to Sub-Repos` 已 **23/23 全绿**(此前 3 个 failure)。

**2. 修复 `$EXCLUDES` 死代码**

workflow 花约 25 行从 `sync.yaml` 解析出 `$EXCLUDES`,然后**从未传给 rsync**。所有 per-mapping `exclude:` 配置都只是装饰 —— 今后有人加 `- internal.md` 会被静默忽略,文件照样发到公开仓库。

**3. `rsync --delete` 保护治理文件**

原先只保护 `.git/.github/.gitbooks`。目标仓库里新增的 `LICENSE`、`SECURITY.md` 会在下次同步被无声抹掉 —— 对刚建的 8 个公开仓尤其现实。

**4. README 映射表补全**

表格早已滞后。`aichat` 那行原本标注"无独立仓库",本次改动会让它**由对变错**,故一并补全全部 27 行。

## 验证

- 在 `ubuntu:22.04`(与 CI 同为 GNU sed/grep)逐字复刻解析循环:27/27 全部解析出 `--exclude=.github --exclude=.gitbooks`,repo 映射逐一正确 → 接上 `$EXCLUDES` 今天是 no-op,零行为变化。
  - 注:本地 macOS 复现会得到 54 个 key,因 BSD `sed 's/^\s*//'` 不剥前导空格,`grep -v '^exclude$'` 因而失效。这是 macOS 假象,CI 上为 27。
- 实测新 rsync flags:`.github`/`.gitbooks`/`LICENSE`/`CONTRIBUTING`/`SECURITY` 全部保留,过时文件仍被正确剪枝(`--delete` 语义未受损)。
- 8 个新仓内容与 monorepo 子目录 blob SHA 逐一一致 → 首次同步为 no-op。

> 合并后不会自动触发同步:仅改 `sync.yaml` 的 push 不匹配任何 `^<dir>/`,`detect-changes` 会跳过 sync job。需等周一 03:00 UTC cron 或手动 `workflow_dispatch`,且预期全部输出 `No changes to sync`。

## 🤖 对抗评审

Codex 额度耗尽,回退 Claude `general-purpose` subagent(符合 AGENTS.md 的自动检测回退)。

评审逐项模拟了 shell 解析循环、比对了全部 27 个 key 的前缀碰撞、用 `gh api` 核验了 8 个仓库名的逐字节大小写,并追查了最近一次失败的定时同步。结论 4 条 RISK:

| # | RISK | 处理 |
|---|---|---|
| 1 | `$EXCLUDES` 解析后从未使用,是死代码;本 PR 又新增 20 行同类配置,加固了这个陷阱 | **已修** — 接上 rsync,并在 Linux 下验证 27/27 无行为变化 |
| 2 | `rsync --delete` 不保护 LICENSE/CONTRIBUTING/SECURITY,新建公开仓加 LICENSE 后会被周一 cron 抹掉 | **已修** — 显式 exclude,并实测确认 |
| 3 | README:22 的 `aichat` 行会由对变错,另 4 个新映射无对应行 | **已修** — 补全全部 27 行 |
| 4 | 仅改 sync.yaml 的 push 不会触发同步,合并后不要误以为配置有问题 | **接受** — 非缺陷,已在上方"验证"中说明 |

评审另确认为**非缺陷**(已逐一核实,不作改动):`IN_DIR` 未初始化在首轮即为 false,是正确行为;文件末尾映射靠 EOF 正常终止,不依赖后续行;27 个 key 两两无前缀碰撞;`openai` 重复的 `.gitbooks` 是重复**列表项**而非重复 key,YAML 合法;`SYNC_TOKEN` 无 per-repo allowlist,新建仓无需改 secret(由 06:22 那次成功同步 fish/face/wan 证实)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)