### PR TITLE
docs: document the Fish model header, refresh Claude lineup, drop an internal alias

### DIFF
--- a/claude/docs/claude_messages_api_integration_guide.md
+++ b/claude/docs/claude_messages_api_integration_guide.md
@@ -18,7 +18,7 @@ Upon first application, there will be a free quota provided, allowing you to use
 
 The request path for the Claude Messages API is `/v1/messages`, consistent with the Anthropic official API. We need to provide at least three required parameters:
 
-- `model`: Choose the Claude model to use, such as `claude-opus-4-20250514`, `claude-sonnet-4-20250514`, etc.
+- `model`: Choose the Claude model to use. The current lineup leads with `claude-fable-5`, `claude-opus-5`, `claude-opus-4-8` and `claude-sonnet-5`; older releases such as `claude-opus-4-20250514` and `claude-sonnet-4-20250514` remain available.
 - `messages`: An array of input messages, each containing `role` (role) and `content` (content), where `role` supports `user` and `assistant`.
 - `max_tokens`: The maximum number of output tokens, used to limit the length of a single reply.
 

--- a/claude/docs/claude_messages_count_tokens_api_integration_guide.md
+++ b/claude/docs/claude_messages_count_tokens_api_integration_guide.md
@@ -16,7 +16,7 @@ This API is completely free to use and does not consume any quota.
 
 The request path for the Claude Messages Count Tokens API is `/v1/messages/count_tokens`, consistent with the official Anthropic API. We need to provide at least two required parameters:
 
-- `model`: Choose the Claude model to use, such as `claude-sonnet-4-5-20250929`, `claude-opus-4-20250514`, etc.
+- `model`: Choose the Claude model to use. The current lineup leads with `claude-fable-5`, `claude-opus-5`, `claude-opus-4-8` and `claude-sonnet-5`; older releases such as `claude-sonnet-4-5-20250929` remain available.
 - `messages`: An array of input messages, each containing `role` and `content`.
 
 Common optional parameters:

--- a/fish/docs/fish_tts_api_integration_guide.md
+++ b/fish/docs/fish_tts_api_integration_guide.md
@@ -28,6 +28,11 @@ The most basic usage is to input `text`. The result is a synthesized audio file.
 - `callback_url`: an asynchronous callback URL.
 - `async`: optional. When `true`, the API returns immediately with a `task_id`; poll the result with the Fish Tasks API.
 
+> The TTS engine is selected with the **`model` request header** — not a body field.
+> Supported values are `s1`, `s2-pro` (default) and `s2.1-pro`. `s2.1-pro` is the latest
+> generation and `s2-pro` is the most expressive, while `s1` is steadier on long passages.
+> All three are priced the same.
+
 ### Request Example
 
 ```bash

--- a/gemini/docs/gemini_chat_completions_api_integration_guide.md
+++ b/gemini/docs/gemini_chat_completions_api_integration_guide.md
@@ -402,7 +402,7 @@ It can be seen from the above that the Gemini 3.0 model supports multimodal unde
 
 ## Gemini-3.1 Multimodal Model
 
-Gemini 3.1 Pro is an upgraded version of Gemini 3.0 Pro, with the underlying model being `gemini-3.1-pro-preview`, also supporting multimodal inputs such as text, images, and videos, with stronger reasoning and understanding capabilities. The usage is completely consistent with Gemini 3.0 Pro; just replace the `model` parameter with `gemini-3.1-pro`.
+Gemini 3.1 Pro is an upgraded version of Gemini 3.0 Pro, also supporting multimodal inputs such as text, images, and videos, with stronger reasoning and understanding capabilities. The usage is completely consistent with Gemini 3.0 Pro; just replace the `model` parameter with `gemini-3.1-pro`.
 
 Request example:
 


### PR DESCRIPTION
## 改动

### fish —— `s2.1-pro` 此前无从发现

TTS 指南**完全没提**可以选择引擎。它是一个**请求头**(不是 body 字段),所以客户无从知道 `s2.1-pro` 的存在。已补充,并注明默认 `s2-pro` 及三者差异(依据 PlatformBackend 权威中文文档)。

> 说明放在 body 字段列表**之后** —— 初版我插在列表中间,对抗评审指出空行+引用块会**截断 Markdown 列表**,导致后续 `format`/`sample_rate` 等重启为新列表;且 `model` 是 header,放在「request body fields」中间语义也不对。

### claude —— 指南仍停留在 2024/2025 模型

`claude_messages_*` 与 `count_tokens_*` 只列了 `claude-opus-4-20250514` 一类旧模型。改为以当前阵容(`claude-fable-5` / `claude-opus-5` / `claude-opus-4-8` / `claude-sonnet-5`)领衔,同时说明旧 id 仍然可用(已核对 enum,旧模型确实还在)。

### gemini —— 移除内部实现措辞

删除「底层模型为 `gemini-3.1-pro-preview`」。该 id 不在公开 enum 与 `config/models.json` 中,向客户描述内部实现没有意义。

## 范围说明(评审驱动的重要调整)

初版我还改了 `openai/` 和 `sora/`。对抗评审指出:**这两个目录由 PlatformBackend 的 `repo/repo.py` 从数据库生成**,`CONFIG` 中包含 `OpenAIAPI` 与 `SoraAPI`,而生成逻辑会:

```python
for filename in os.listdir(docs_folder):
    os.remove(file_path)          # 先清空整个 docs/
...
f.write(translate(document2.content).encode("utf-8"))
```

即**整目录清空重写**。在公开仓手改必被覆盖 —— 与 AGENTS.md 对 `Docs/**/*.mdx` 的规则同理。故已全部回退,相关修复改在源头提交:**https://github.com/AceDataCloud/PlatformBackend/pull/1169**(修正 `dall-e-2` 已下线却仍被宣称支持 `n > 1`)。

本 PR 仅保留 `claude/`、`fish/`、`gemini/` 三个**非生成**目录。

## 遗留(已确认但本 PR 不处理)

评审另发现两类问题,均需在数据库/源头处理,记录在此以免遗漏:

1. **`openai/docs/openai_chat_completions_4o_image_*` 含供应商 CDN 域名 `file.onechats.ai`(6 处)。** 该域名在 PlatformBackend 中 0 处命中,说明内容来自 Translation 表。由于该目录被生成器覆盖,直接改文件无效,需修数据库中的文档内容。
2. **`filesystem.site`(sora/openai)与 `file.aigpai.com`(hailuo)** 属同类供应商域名,且在 PlatformBackend 的 `docs/`、`openapi/` 中同样存在 —— 需在源头统一处理,否则会被重新生成。

## 🤖 对抗评审

Codex 额度耗尽,回退 Claude `general-purpose` subagent。评审共 6 条 RISK,其中 **2 条直接改变了本 PR 的范围与做法**:

| # | RISK | 处理 |
|---|---|---|
| 5 | **`openai/`、`sora/` 是 DB 生成目录,手改会被清空覆盖** | **已采纳** — 复核 `repo/repo.py` 属实,回退这 5 个文件,改在源头开 PB#1169 |
| 1 | `dall-e-2` 实际不可用,却被宣称支持 `n>1`(错误继承自中文源文档) | **已采纳** — 复验 400 属实,在 PB#1169 从源头修正 |
| 6 | fish 说明插入位置截断了 Markdown 列表 | **已修** — 移到列表之后 |
| 3 | 我编造的 `cdn.acedata.cloud/example/...` 占位 URL 返回 404 | **已随回退消除**(该改动属 openai/ 生成目录) |
| 4 | `filesystem.site` / `file.aigpai.com` 同类泄漏未清 | **记录在「遗留」** — 需在 PB 源头处理,否则会被重新生成 |
| 2 | `nano-banana-pro` 的 `n>1` 未经实测 | **已随回退消除**;我实测过 `gpt-image-2`(2 图/0.2024 credits)与 `nano-banana-2`(2 图/0.5152 credits) |

评审确认无误的部分:fish header enum 与 spec 完全一致;Claude 四个新模型均在 enum 中;`gemini-3.1-pro-preview` 确为内部 id;`> [!WARNING]` 语法有效且链接可达;`n` 的按张计费机制(`x-billing-n`)与部分失败只计成功数的表述准确。

🤖 Generated with [Claude Code](https://claude.com/claude-code)