### PR TITLE
docs(webextrator): 示例里的 started_at/finished_at 改成 Unix 浮点秒

### DIFF
--- a/webextrator/README.md
+++ b/webextrator/README.md
@@ -94,8 +94,8 @@ payload, and `description / byline / publishedAt` are back-filled from it:
   "success": true,
   "task_id": "550e8400-e29b-41d4-a716-446655440000",
   "trace_id": "550e8400-e29b-41d4-a716-446655440001",
-  "started_at": "2026-05-02T10:30:00.123Z",
-  "finished_at": "2026-05-02T10:30:02.535Z",
+  "started_at": 1777717800.123,
+  "finished_at": 1777717802.535,
   "elapsed": 2.412,
   "data": {
     "kind": "extract",

--- a/webextrator/docs/webextrator_extract_api_integration_guide.md
+++ b/webextrator/docs/webextrator_extract_api_integration_guide.md
@@ -64,8 +64,8 @@ Extract accepts **everything** Render accepts (see
   "success": true,
   "task_id": "550e8400-e29b-41d4-a716-446655440000",
   "trace_id": "550e8400-e29b-41d4-a716-446655440001",
-  "started_at": "2026-05-02T10:30:00.123Z",
-  "finished_at": "2026-05-02T10:30:02.535Z",
+  "started_at": 1777717800.123,
+  "finished_at": 1777717802.535,
   "elapsed": 2.412,
   "data": {
     "kind": "extract",
@@ -218,7 +218,7 @@ Set `async: true` to fire-and-forget (providing `callback_url` also automaticall
   "success": true,
   "task_id": "550e8400-...",
   "trace_id": "6ba7b810-...",
-  "started_at": "2026-05-02T10:30:00.123Z"
+  "started_at": 1777717800.123
 }
 ```
 

--- a/webextrator/docs/webextrator_render_api_integration_guide.md
+++ b/webextrator/docs/webextrator_render_api_integration_guide.md
@@ -81,8 +81,8 @@ The envelope is the standard AceDataCloud `success / error` shape.
   "success": true,
   "task_id": "550e8400-e29b-41d4-a716-446655440000",
   "trace_id": "550e8400-e29b-41d4-a716-446655440001",
-  "started_at": "2026-05-02T10:30:00.123Z",
-  "finished_at": "2026-05-02T10:30:01.234Z",
+  "started_at": 1777717800.123,
+  "finished_at": 1777717801.234,
   "elapsed": 1.111,
   "data": {
     "kind": "render",
@@ -123,7 +123,7 @@ When `async=true` (or when `callback_url` is provided), the platform immediately
   "success": true,
   "task_id": "550e8400-...",
   "trace_id": "6ba7b810-...",
-  "started_at": "2026-05-02T10:30:00.123Z"
+  "started_at": 1777717800.123
 }
 ```
 
@@ -156,8 +156,8 @@ Errors share the standard envelope:
   "success": false,
   "task_id": "...",
   "trace_id": "...",
-  "started_at": "...",
-  "finished_at": "...",
+  "started_at": 1777717800.123,
+  "finished_at": 1777717800.135,
   "elapsed": 0.012,
   "error": {
     "code": "bad_request",
@@ -243,7 +243,7 @@ curl -X POST https://api.acedata.cloud/webextrator/render \
   }'
 ```
 
-You will receive `{ "success": true, "task_id": "...", "trace_id": "...", "started_at": "..." }` immediately;
+You will receive `{ "success": true, "task_id": "...", "trace_id": "...", "started_at": 1777717800.123 }` immediately;
 when the task finishes the platform will POST the complete result to your `callback_url`.
 
 ### Forcing a re-render past the cache

--- a/webextrator/docs/webextrator_tasks_api_integration_guide.md
+++ b/webextrator/docs/webextrator_tasks_api_integration_guide.md
@@ -65,8 +65,8 @@ Exactly one of `ids` or `trace_ids` must be supplied.
     "trace_id": "550e8400-e29b-41d4-a716-446655440001",
     "type": "extract",
     "created_at": 1730000000000,
-    "started_at": "2026-05-02T10:30:00.123Z",
-    "finished_at": "2026-05-02T10:30:02.535Z",
+    "started_at": 1777717800.123,
+    "finished_at": 1777717802.535,
     "elapsed": 2.412,
     "request": {
       "url": "https://en.wikipedia.org/wiki/Diffbot",


### PR DESCRIPTION
跟随平台的计时字段统一（[PlatformService#1778](https://github.com/AceDataCloud/PlatformService/pull/1778)）。

`APIs/webextrator/` 是**手工维护**的（不像 `APIs/openai` / `APIs/sora` 由 `repo.py` 生成），所以不会被自动刷新。

10 处示例值 + render 指南里的 `"..."` 字符串占位符 —— 字段已是 `number`，用字符串占位会误导。

🤖 Generated with [Claude Code](https://claude.com/claude-code)