### PR TITLE
suno: state the real duration contract

### DIFF
--- a/suno/docs/suno_audios_generation_api_integration_guide.md
+++ b/suno/docs/suno_audios_generation_api_integration_guide.md
@@ -63,7 +63,7 @@ Additionally, we set the Request Body, including:
 - `replace_section_start`: the starting time for the replacement segment.
 - `vocal_gender`: control of male and female voices, female voice `f`, male voice `m`, effective for models 4.5 and above.
 - `weirdness`: advanced parameter for `weirdness`.
-- `duration`: the target length of the generated track in seconds, given as an integer, typically between 10 and 360. It is mainly used for generation in custom mode (`custom` is `true`); some models or actions may not support it, in which case the value is ignored or an error is returned. This is a target — the actual length of each returned track is reported by the `duration` field in the response and may vary slightly.
+- `duration`: the target length of the generated track in seconds, given as an integer between 10 and 360. It is used for generation in custom mode (`custom` is `true`). It is a hint rather than a bound — the model takes it into account but does not commit to it, and the actual length of each returned track is reported by the `duration` field in the response, usually shorter than the value you asked for.
 - `lyric_prompt`: the prompt for generating lyrics, effective only when `custom` is `true` and `lyric` is not provided.
 - `callback_url`: the URL for callback results.
 
@@ -1012,9 +1012,9 @@ Thus, custom songs were generated using advanced parameters, and the results are
 
 ## Controlling Track Length
 
-By default the model decides how long a generated track is, typically somewhere between 30 seconds and 4 minutes. To ask for a longer or shorter result, pass `duration` — an integer number of seconds, usually somewhere between 10 and 360.
+By default the model decides how long a generated track is, typically somewhere between 30 seconds and 4 minutes. To ask for a longer or shorter result, pass `duration` — an integer number of seconds between 10 and 360.
 
-It is mainly intended for custom mode (`custom` is `true`), which is where it has the most effect. Support varies by model and action, so it is worth trying your combination and checking the returned track length.
+It is used for custom mode (`custom` is `true`). Note that `duration` is a **hint, not a bound**: the model weighs it while composing but does not commit to it. In practice the result is often noticeably shorter than requested, and the two tracks in a single response can differ several-fold. Do not treat it as precise length control — if you need an exact length, trim the finished track or retry.
 
 The corresponding Python code:
 
@@ -1043,9 +1043,9 @@ response = requests.post(url, json=payload, headers=headers)
 print(response.text)
 ```
 
-Note that `duration` in the **request** is the length you are asking for, while the `duration` field on each track in the **response** is that track's **actual** length. The two share a name but mean different things, and the actual value varies around the requested one rather than matching it exactly.
+Note that `duration` in the **request** is the length you are asking for, while the `duration` field on each track in the **response** is that track's **actual** length. The two share a name but mean different things, and the actual value is not guaranteed to match the requested one. Lyric length is one of the main drivers of the finished length, so if you want a longer track, supply fuller lyrics as well.
 
-Whether a particular combination is honoured is decided by the model, so if a value has no effect, try a different model or switch to custom mode.
+The API does not validate `duration` — the value is passed through to the model as given. If you pass something the current mode or model does not act on, it simply has no effect, so try one request first before using it at scale.
 
 ## Add Instrumental Function
 


### PR DESCRIPTION
Follow-up to #632. I documented `duration` from assumption; this time I measured it.

Called the service directly with the same lyrics in custom mode:

| request | returned |
|---|---|
| `duration: 240`, chirp-v5 | 118.5s / 169.4s |
| **no duration**, chirp-v5 | 88.3s / 65.0s |
| `duration: 240`, chirp-v5-5 | 45.4s / 112.7s |

It moves the result but never lands on it, and two tracks in one response can differ several-fold.

- **Restored `10-360` and custom mode.** Both are real parts of the contract; #632 softened them to "typically" / "mainly" on my mistaken belief that I had invented them.
- **Dropped "may vary slightly".** That promised a precision the service does not deliver.
- Kept the note that we do not validate the value — it is forwarded as given.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)