### PR TITLE
Remove unavailable Seedream 3.0 models from docs

### DIFF
--- a/coze/seedream.yaml
+++ b/coze/seedream.yaml
@@ -41,11 +41,10 @@ paths:
                 model:
                   type: string
                   enum:
+                    - doubao-seedream-5-0-pro-260628
                     - doubao-seedream-5-0-260128
                     - doubao-seedream-4-5-251128
                     - doubao-seedream-4-0-250828
-                    - doubao-seedream-3-0-t2i-250415
-                    - doubao-seededit-3-0-i2i-250628
                   default: doubao-seedream-5-0-260128
                   description: Seedream model version. Newer versions generally look better.
                 size:
@@ -58,9 +57,6 @@ paths:
                     - adaptive
                   default: 2K
                   description: Output resolution tier.
-                seed:
-                  type: integer
-                  description: Optional seed for reproducible results.
                 output_format:
                   type: string
                   enum:

--- a/seedream/README.md
+++ b/seedream/README.md
@@ -8,7 +8,7 @@ Keywords: seedream-api, ai-image, image-generation, image-editing, bytedance, do
 
 ## Overview
 
-The Seedream Images API generates and edits ByteDance Seedream (Doubao) images by inputting custom parameters. Models: `doubao-seedream-3-0-t2i-250415`, `doubao-seedream-4-0-250828`, `doubao-seedream-4-5-251128`, `doubao-seedream-5-0-260128`, `doubao-seedream-5-0-pro-260628`, and `doubao-seededit-3-0-i2i-250628` (image edit). The Seedream Tasks API queries async task status.
+The Seedream Images API generates and edits images with `doubao-seedream-4-0-250828`, `doubao-seedream-4-5-251128`, `doubao-seedream-5-0-260128`, and `doubao-seedream-5-0-pro-260628`. The Seedream Tasks API queries async task status.
 
 ## Quick Start
 
@@ -27,8 +27,6 @@ curl --request POST "https://api.acedata.cloud/seedream/images" \
 | `doubao-seedream-5-0-260128` | Latest, highest quality (推荐) |
 | `doubao-seedream-4-5-251128` | 4.5 |
 | `doubao-seedream-4-0-250828` | 4.0 |
-| `doubao-seedream-3-0-t2i-250415` | 3.0 text-to-image |
-| `doubao-seededit-3-0-i2i-250628` | SeedEdit 3.0 image editing |
 
 ## APIs and Guides
 

--- a/seedream/docs/seedream_images_generation_api_integration_guide.md
+++ b/seedream/docs/seedream_images_generation_api_integration_guide.md
@@ -10,10 +10,10 @@ Apply for the service on the [Seedream Images API](https://platform.acedata.clou
 
 Request body fields:
 
-- `model`: one of `doubao-seedream-5-0-pro-260628`, `doubao-seedream-5-0-260128`, `doubao-seedream-4-5-251128`, `doubao-seedream-4-0-250828`, `doubao-seedream-3-0-t2i-250415`, `doubao-seededit-3-0-i2i-250628`.
+- `model`: one of `doubao-seedream-5-0-pro-260628`, `doubao-seedream-5-0-260128`, `doubao-seedream-4-5-251128`, `doubao-seedream-4-0-250828`.
 - `prompt`: image description (required).
-- `size`: output resolution `1K` / `2K` / `4K`.
-- `image_url`: source image for editing (SeedEdit `doubao-seededit-3-0-i2i-250628`).
+- `size`: output resolution; supported presets vary by model. 5.0 Pro supports `1K`/`2K`, 5.0 Lite supports `2K`/`3K`/`4K`, 4.5 supports `2K`/`4K`, and 4.0 supports `1K`/`2K`/`4K`.
+- `image`: source image URL or Base64 value array for editing. All supported models accept image input.
 - `callback_url` / `async`: async modes; `async: true` returns a `task_id` polled via Seedream Tasks API.
 
 ### Request Example
@@ -41,15 +41,15 @@ curl -X POST 'https://api.acedata.cloud/seedream/images' \
 }
 ```
 
-## Image Editing (SeedEdit)
+## Image Editing
 
-Use `doubao-seededit-3-0-i2i-250628` with `image_url`:
+Use a supported model with the `image` array:
 
 ```json
 {
-  "model": "doubao-seededit-3-0-i2i-250628",
+  "model": "doubao-seedream-5-0-260128",
   "prompt": "make the sky golden hour, add warm tone",
-  "image_url": "https://example.com/photo.png"
+  "image": ["https://example.com/photo.png"]
 }
 ```
 


### PR DESCRIPTION
## Summary
- remove unavailable Seedream 3.0 T2I and SeedEdit 3.0 from the published API README and integration guide
- update image editing examples to use Seedream 5.0 Lite and the current `image` array field
- align the Coze schema with 5.0 Pro, 5.0 Lite, 4.5, and 4.0 and remove unsupported `seed`

## Validation
- YAML parse check for `coze/seedream.yaml`
- retired-model reference scan
- `git diff --check`

## Dependency / rollout
Public documentation sync for PlatformService / PlatformBackend Seedream v3 withdrawal.

Rollback: revert this commit.