### PR TITLE
docs(suno): document negative_tags parameter

### DIFF
--- a/suno/docs/suno_audios_generation_api_integration_guide.md
+++ b/suno/docs/suno_audios_generation_api_integration_guide.md
@@ -50,7 +50,7 @@ Additionally, we set the Request Body, including:
 - `instrumental`: the pure music option for the inspiration mode from Suno.
 - `title`: the music title for the custom mode from Suno.
 - `style`: the music style for the custom mode from Suno.
-- `style_negative`: the excluded style for the custom mode from Suno.
+- `negative_tags`: music styles or genres to exclude when `custom` is `true`.
 - `audio_weight`: the proportion of the uploaded reference audio, range 0-1, the larger the more it relies on the reference audio.
 - `audio_id`: the ID of the reference music.
 - `overpainting_start`/`overpainting_end`: the start and end time in seconds for adding vocals to existing pure music.


### PR DESCRIPTION
## Contract
Standardize the public Suno excluded-style request field as `negative_tags`. Runtime workers retain `style_negative` only as a compatibility alias, with `negative_tags` taking precedence.

## Dependency graph
PlatformService runtime -> PlatformBackend contract/docs -> MCP, Dify, Skills, APIs, Nexior clients.

## Review
Adversarial review not requested.

## Rollout / rollback
This is additive at runtime and non-billing. Roll back the repository commit if needed; old clients continue working during rollout.

Depends on the PlatformBackend contract PR.

## Validation
- Markdown diff check passed.