### PR TITLE
fix(sync): publish MiniMax API mirror

### DIFF
--- a/minimax/README.md
+++ b/minimax/README.md
@@ -2,6 +2,8 @@
 
 Generate 4–15 second videos from text, one to nine reference images, or one to three audio references through AceDataCloud.
 
+MCP integration: [MiniMax H3 MCP](https://github.com/AceDataCloud/MinimaxMCP).
+
 ## Endpoints
 
 | Method | Path | Purpose |

--- a/sync.yaml
+++ b/sync.yaml
@@ -90,6 +90,11 @@ mappings:
     exclude:
       - .github
       - .gitbooks
+  minimax:
+    repo: AceDataCloud/MiniMaxAPI
+    exclude:
+      - .github
+      - .gitbooks
   happyhorse:
     repo: AceDataCloud/HappyHorseAPI
     exclude:


### PR DESCRIPTION
## Summary
- map `minimax/` to the new public `AceDataCloud/MiniMaxAPI` repository
- link the API README to the hosted MiniMax MCP
- trigger a targeted sub-repo sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)