### PR TITLE
docs(minimax): remove watermark parameter

### DIFF
--- a/minimax/docs/videos.md
+++ b/minimax/docs/videos.md
@@ -12,7 +12,6 @@
 | `audio_urls` | string[] | — | 1–3 public HTTP(S) URLs |
 | `resolution` | string | `2K` | `768P` or `2K` |
 | `ratio` | string | `16:9` | `16:9` or `9:16` |
-| `aigc_watermark` | boolean | false | add an AIGC watermark |
 | `duration` | integer | 4 | 4–15 |
 | `async` | boolean | false | return task ID immediately |
 | `callback_url` | string | — | public HTTP(S) webhook |


### PR DESCRIPTION
## Contract

`POST /minimax/videos` (API `64f22fd9-0efd-445e-b0b1-135682fd66d7`) no longer exposes `aigc_watermark`. After the coordinated runtime change, explicitly sending either boolean value is rejected as an unsupported field (HTTP 400), rather than silently ignored.

## Changes and validation

Removes the parameter from the current MiniMax video API guide. Validation: all JSON examples parsed, current MiniMax docs contain no watermark field, and `git diff --check` passed.

## Dependency graph

consumer surfaces → PlatformService runtime enforcement + PlatformBackend OpenAPI/docs → generated Docs/downstream reconciliation

This consumer removal is safe to merge before the runtime/contract switch because it only stops emitting an optional field whose existing default is already `false`.

## Rollout / rollback

Release before or with the PlatformService and PlatformBackend PRs. Roll back together with the coordinated set; do not restore the parameter in only one surface.

## Out of scope

Legacy `/hailuo/videos`, billing rules, generated Docs files, and historical validation reports.

Adversarial review: not requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
