### PR TITLE
docs(suno): correct lyrics model options

### DIFF
--- a/suno/README.md
+++ b/suno/README.md
@@ -707,7 +707,7 @@ Integrate Suno AI music generation capabilities into your application through a 
 <div class="feat-card">
 <div class="feat-icon">📝</div>
 <h3>AI Lyrics Generation</h3>
-<p>Automatically generate structured lyrics with paragraph markers (verse, chorus, bridge) using the <code>default</code> or <code>remi-v1</code> model. Also supports mashup lyrics, blending the lyrics of two songs.</p>
+<p>Automatically generate structured lyrics with paragraph markers (verse, chorus, bridge). The required <code>model</code> parameter accepts <code>default</code> or <code>remi-v1</code>. Also supports mashup lyrics, blending the lyrics of two songs.</p>
 </div>
 <div class="feat-card">
 <div class="feat-icon">🔀</div>

--- a/suno/README.md
+++ b/suno/README.md
@@ -707,7 +707,7 @@ Integrate Suno AI music generation capabilities into your application through a 
 <div class="feat-card">
 <div class="feat-icon">📝</div>
 <h3>AI Lyrics Generation</h3>
-<p>Automatically generate structured lyrics with paragraph markers (verse, chorus, bridge) using two AI models. Also supports mashup lyrics, blending the lyrics of two songs.</p>
+<p>Automatically generate structured lyrics with paragraph markers (verse, chorus, bridge) using the <code>default</code> or <code>remi-v1</code> model. Also supports mashup lyrics, blending the lyrics of two songs.</p>
 </div>
 <div class="feat-card">
 <div class="feat-icon">🔀</div>

--- a/suno/docs/suno_lyrics_generation_api_integration_guide.md
+++ b/suno/docs/suno_lyrics_generation_api_integration_guide.md
@@ -2,7 +2,7 @@
 
 If you want to customize song generation but don't want to write the lyrics yourself, you can use the lyrics generation API provided by AceDataCloud to generate lyrics through a prompt. The API is the [Suno Lyrics Generation API](https://platform.acedata.cloud/documents/514d82dc-f7ab-4638-9f21-8b9275916b08).
 
-The main input parameter for this API is `prompt`, with an optional `model` (default is chirp-v3). An example of how to fill it out is as follows:
+The main input parameter for this API is `prompt`, with an optional `model`. Supported values are `default` and `remi-v1`; when omitted, `model` defaults to `default`. An example of how to fill it out is as follows:
 
 ![](https://cdn.acedata.cloud/p53wtj.png)
 

--- a/suno/docs/suno_lyrics_generation_api_integration_guide.md
+++ b/suno/docs/suno_lyrics_generation_api_integration_guide.md
@@ -2,7 +2,7 @@
 
 If you want to customize song generation but don't want to write the lyrics yourself, you can use the lyrics generation API provided by AceDataCloud to generate lyrics through a prompt. The API is the [Suno Lyrics Generation API](https://platform.acedata.cloud/documents/514d82dc-f7ab-4638-9f21-8b9275916b08).
 
-The main input parameter for this API is `prompt`, with an optional `model`. Supported values are `default` and `remi-v1`; when omitted, `model` defaults to `default`. An example of how to fill it out is as follows:
+The required input parameters for this API are `prompt` and `model`. Set `model` to either `default` or `remi-v1`. An example of how to fill them out is as follows:
 
 ![](https://cdn.acedata.cloud/p53wtj.png)
 


### PR DESCRIPTION
## Summary
- document the required Suno Lyrics `model` field with `default` and `remi-v1`
- clarify that callers must select either `default` or `remi-v1`
- align the Suno README lyrics feature copy with the same public model contract

## Dependency
- Depends on the PlatformBackend Suno contract PR: https://github.com/AceDataCloud/PlatformBackend/pull/1414

## Tests
- `git diff --check origin/main...HEAD`
- searched Suno README and lyrics guides to confirm no `chirp-v3` remains in the lyrics-model documentation
- verified only the two intended documentation files changed

## Rollback
- Revert commit `4911565` to restore the previous documentation text.

## Out of scope
- no API, schema, runtime, pricing, or generated-doc changes
- no changes to valid `chirp-*` models documented for the Suno Audios API

This PR is intentionally not merged.


