### PR TITLE
docs(flux): remove exposed credential screenshot

### DIFF
--- a/flux/docs/flux_images_generation_api_integration_guide.md
+++ b/flux/docs/flux_images_generation_api_integration_guide.md
@@ -45,11 +45,9 @@ The parameter `size` has some special restrictions, mainly divided into two type
 
 Reference image ratios: "1:1", "16:9", "21:9", "3:2", "2:3", "4:5", "5:4", "3:4", "4:3", "9:16", "9:21",
 
-After selection, you can see that the corresponding code is also generated on the right side, as shown in the image below:
+After selection, the corresponding code is generated on the right side. Before copying it, confirm that the authorization header uses your own API key; real credentials must never appear in documentation or screenshots.
 
-<p><img src="https://cdn.acedata.cloud/8q7aux.png" width="500" class="m-auto"></p>
-
-Click the "Try" button to test, as shown in the image above, and we get the following result:
+Click the "Try" button to test, and we get the following result:
 
 ```json
 {


### PR DESCRIPTION
## Summary
- remove the Flux integration-guide screenshot that exposed a real API credential
- keep the existing redacted code samples and add an explicit credential-safety warning

## Incident response
- exposed Credential revoked
- source COS object deleted and exact EdgeOne URL purged; public URL now returns 404

## Validation
- `git diff --check`
- no `8q7aux` reference remains under `flux/docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)