### PR TITLE
docs(claude): migrate retired model examples

### DIFF
--- a/claude/docs/claude_chat_completions_api_integration_guide.md
+++ b/claude/docs/claude_chat_completions_api_integration_guide.md
@@ -35,6 +35,8 @@ Common optional parameters:
 
 After the call, we find that the return result is as follows:
 
+> Historical response snapshot from a retired model; retained only to demonstrate the response structure.
+
 ```json
 {
   "id": "msg_bdrk_01Q6WN27v95ypCa1kbanAQ6K",
@@ -114,7 +116,7 @@ headers = {
 }
 
 payload = {
-    "model": "claude-opus-4-20250514",
+    "model": "claude-opus-5",
     "messages": [{"role":"user","content":"Hello"}],
     "stream": True
 }
@@ -124,6 +126,8 @@ print(response.text)
 ```
 
 The output effect is as follows:
+> Historical response snapshot from a retired model; retained only to demonstrate the response structure.
+
 ```json
 data: {"id": "msg_bdrk_01LPPqDjLKMgfSwTRMRty9VT", "object": "chat.completion.chunk", "created": 1768619445, "model": "claude-opus-4-20250514", "system_fingerprint": null, "choices": [{"delta": {"content": "", "role": "assistant"}, "logprobs": null, "finish_reason": null, "index": 0}], "usage": null}
 
@@ -159,7 +163,7 @@ const options = {
     "content-type": "application/json",
   },
   body: JSON.stringify({
-    model: "claude-opus-4-20250514",
+    model: "claude-opus-5",
     messages: [{ role: "user", content: "Hello" }],
     stream: true,
   }),
@@ -175,7 +179,7 @@ Java sample code:
 
 ```java
 JSONObject jsonObject = new JSONObject();
-jsonObject.put("model", "claude-opus-4-20250514");
+jsonObject.put("model", "claude-opus-5");
 jsonObject.put("messages", [{"role":"user","content":"Hello"}]);
 jsonObject.put("stream", true);
 MediaType mediaType = "application/json; charset=utf-8".toMediaType();
@@ -215,7 +219,7 @@ headers = {
 }
 
 payload = {
-    "model": "claude-opus-4-20250514",
+    "model": "claude-opus-5",
     "messages": [{"role":"user","content":"Hello"},{"role":"assistant","content":"Hello! How can I help you today?"},{"role":"user","content":"What I say just now?"}]
 }
 
@@ -224,6 +228,8 @@ print(response.text)
 ```
 
 By uploading multiple question words, you can easily achieve multi-turn dialogue and receive the following response:
+
+> Historical response snapshot from a retired model; retained only to demonstrate the response structure.
 
 ```json
 {
@@ -268,7 +274,7 @@ It can be seen that the information contained in `choices` is consistent with th
 
 ## Deep Thinking Model
 
-The claude-opus-4-20250514-thinking and claude-sonnet-4-20250514-thinking models are different from other models in that they can perform deep thinking based on the question words to provide answers, and return the results of the thinking process to you. This article will demonstrate the deep thinking functionality through a specific example. Next, you can fill in the corresponding content on the Claude Chat Completion API interface, as shown in the figure:
+`claude-opus-5` and `claude-sonnet-5` support deep thinking through request parameters; no `-thinking` model suffix is needed. The historical response below is retained only to demonstrate the reasoning field structure, and its model has retired.
 
 <p><img src="https://cdn.acedata.cloud/d1a4wq.png" width="400" class="m-auto" /></p>
 
@@ -277,6 +283,8 @@ At the same time, you can notice that there is corresponding code generation on 
 <p><img src="https://cdn.acedata.cloud/21nmzq.png" width="400" class="m-auto" /></p>
 
 After the call, we find that the returned result is as follows:
+
+> Historical response snapshot from a retired model; retained only to demonstrate the response structure.
 
 ```json
 {
@@ -312,11 +320,11 @@ It can be seen that the response information in `choices` is obtained after deep
 
 ## Visual Model
 
-The claude-sonnet-4-20250514 is a multimodal large language model developed by Claude, which adds visual understanding capabilities based on claude-4. This model can process both text and image inputs simultaneously, achieving cross-modal understanding and generation.
+The claude-sonnet-5 is a multimodal large language model developed by Claude, which adds visual understanding capabilities based on claude-4. This model can process both text and image inputs simultaneously, achieving cross-modal understanding and generation.
 
-The text processing using the claude-sonnet-4-20250514 model is consistent with the basic usage content mentioned above. Below is a brief introduction on how to use the model's image processing capabilities.
+The text processing using the claude-sonnet-5 model is consistent with the basic usage content mentioned above. Below is a brief introduction on how to use the model's image processing capabilities.
 
-The image processing capability of the claude-sonnet-4-20250514 model is mainly achieved by adding a `type` field to the original `content`, which indicates whether the uploaded content is text or an image, thus utilizing the image processing capabilities of the claude-sonnet-4-20250514 model. The following mainly discusses how to call this functionality using Curl and Python.
+The image processing capability of the claude-sonnet-5 model is mainly achieved by adding a `type` field to the original `content`, which indicates whether the uploaded content is text or an image, thus utilizing the image processing capabilities of the claude-sonnet-5 model. The following mainly discusses how to call this functionality using Curl and Python.
 
 - Curl Script Method
 
@@ -326,7 +334,7 @@ curl -X POST 'https://api.acedata.cloud/v1/chat/completions' \
 -H 'authorization: Bearer {token}' \
 -H 'content-type: application/json' \
 -d '{
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-5",
     "messages": [
       {
         "role": "user",
@@ -361,7 +369,7 @@ headers = {
 }
 
 payload = {
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-5",
     "messages": [
         {
             "role": "user",
@@ -385,6 +393,8 @@ print(response.text)
 ```
 
 Then you can obtain the following result, where the field information in the result is consistent with the above:
+
+> Historical response snapshot from a retired model; retained only to demonstrate the response structure.
 
 ```json
 {
@@ -425,7 +435,7 @@ Then you can obtain the following result, where the field information in the res
   }
 }
 ```
-The content of the response can be seen as based on images, so the text and image processing capabilities of the claude-sonnet-4-20250514 model can be easily utilized through the above two methods.
+The content of the response can be seen as based on images, so the text and image processing capabilities of the claude-sonnet-5 model can be easily utilized through the above two methods.
 
 ## Error Handling
 

--- a/claude/docs/claude_messages_api_integration_guide.md
+++ b/claude/docs/claude_messages_api_integration_guide.md
@@ -18,7 +18,7 @@ Upon first application, there will be a free quota provided, allowing you to use
 
 The request path for the Claude Messages API is `/v1/messages`, consistent with the Anthropic official API. We need to provide at least three required parameters:
 
-- `model`: Choose the Claude model to use. The current lineup leads with `claude-fable-5`, `claude-opus-5`, `claude-opus-4-8` and `claude-sonnet-5`; older releases such as `claude-opus-4-20250514` and `claude-sonnet-4-20250514` remain available.
+- `model`: Choose the Claude model to use. The current lineup leads with `claude-fable-5`, `claude-opus-5`, `claude-opus-4-8` and `claude-sonnet-5`.
 - `messages`: An array of input messages, each containing `role` (role) and `content` (content), where `role` supports `user` and `assistant`.
 - `max_tokens`: The maximum number of output tokens, used to limit the length of a single reply.
 
@@ -41,7 +41,7 @@ curl -X POST 'https://api.acedata.cloud/v1/messages' \
   -H 'authorization: Bearer {token}' \
   -H 'content-type: application/json' \
   -d '{
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-5",
     "max_tokens": 1024,
     "messages": [
       {
@@ -66,7 +66,7 @@ headers = {
 }
 
 payload = {
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-5",
     "max_tokens": 1024,
     "messages": [
         {"role": "user", "content": "Hello, Claude"}
@@ -78,6 +78,8 @@ print(response.json())
 ```
 
 After the call, the returned result is as follows:
+
+> Historical response snapshot from a retired model; retained only to demonstrate the response structure.
 
 ```json
 {
@@ -129,7 +131,7 @@ headers = {
 }
 
 payload = {
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-5",
     "max_tokens": 1024,
     "system": "You are a professional Chinese translation assistant. Please translate the user's input from English to Chinese.",
     "messages": [
@@ -161,7 +163,7 @@ headers = {
 }
 
 payload = {
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-5",
     "max_tokens": 1024,
     "stream": True,
     "messages": [
@@ -185,6 +187,8 @@ Streaming responses are returned in Server-Sent Events (SSE) format, with each l
 - `message_stop`: Message end.
 
 The output effect is as follows:
+> Historical response snapshot from a retired model; retained only to demonstrate the response structure.
+
 ```
 event: message_start
 data: {"type":"message_start","message":{"id":"msg_01XFDUDYJgAACzvnptvVoYEL","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":12,"output_tokens":0}}}
@@ -224,7 +228,7 @@ const options = {
     "content-type": "application/json",
   },
   body: JSON.stringify({
-    model: "claude-sonnet-4-20250514",
+    model: "claude-sonnet-5",
     max_tokens: 1024,
     stream: true,
     messages: [{ role: "user", content: "Hello, Claude" }],
@@ -260,7 +264,7 @@ headers = {
 }
 
 payload = {
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-5",
     "max_tokens": 1024,
     "messages": [
         {"role": "user", "content": "Hello, my name is Alice."},
@@ -274,6 +278,8 @@ print(response.json())
 ```
 
 The response is as follows:
+
+> Historical response snapshot from a retired model; retained only to demonstrate the response structure.
 
 ```json
 {
@@ -316,11 +322,13 @@ headers = {
 }
 
 payload = {
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-5",
     "max_tokens": 16000,
     "thinking": {
-        "type": "enabled",
-        "budget_tokens": 10000
+        "type": "adaptive"
+    },
+    "output_config": {
+        "effort": "high"
     },
     "messages": [
         {"role": "user", "content": "What is the sine of 30 degrees? Show your reasoning."}
@@ -332,6 +340,8 @@ print(response.json())
 ```
 
 The response is as follows:
+
+> Historical response snapshot from a retired model; retained only to demonstrate the response structure.
 
 ```json
 {
@@ -365,8 +375,9 @@ As you can see, the `content` array contains two content blocks:
 
 Notes:
 
-- When using `thinking`, `max_tokens` needs to be greater than `budget_tokens`, as `budget_tokens` is the token budget allocated for the thinking process.
-- The larger the `budget_tokens`, the more space the model has for deeper reasoning, suitable for handling complex questions.
+- Current models use `thinking: {"type": "adaptive"}` and decide when and how much to think based on task complexity.
+- Use `output_config.effort` to tune reasoning depth and latency; supported levels depend on the selected model.
+- `max_tokens` covers both thinking and the final answer, so leave sufficient headroom and prefer streaming for large outputs.
 
 ## Visual Model
 
@@ -391,7 +402,7 @@ with open("image.png", "rb") as f:
     image_data = base64.standard_b64encode(f.read()).decode("utf-8")
 
 payload = {
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-5",
     "max_tokens": 1024,
     "messages": [
         {
@@ -431,7 +442,7 @@ headers = {
 }
 
 payload = {
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-5",
     "max_tokens": 1024,
     "messages": [
         {
@@ -465,7 +476,7 @@ curl -X POST 'https://api.acedata.cloud/v1/messages' \
   -H 'authorization: Bearer {token}' \
   -H 'content-type: application/json' \
   -d '{
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-5",
     "max_tokens": 1024,
     "messages": [
       {
@@ -491,6 +502,8 @@ curl -X POST 'https://api.acedata.cloud/v1/messages' \
 Supported image formats include: `image/jpeg`, `image/png`, `image/gif`, `image/webp`.
 
 Example of return result:
+
+> Historical response snapshot from a retired model; retained only to demonstrate the response structure.
 
 ```json
 {
@@ -531,7 +544,7 @@ headers = {
 }
 
 payload = {
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-5",
     "max_tokens": 1024,
     "tools": [
         {
@@ -559,6 +572,8 @@ print(response.json())
 ```
 
 When the model decides to call a tool, the `content` in the return result will contain a `tool_use` type content block:
+
+> Historical response snapshot from a retired model; retained only to demonstrate the response structure.
 
 ```json
 {
@@ -593,7 +608,7 @@ Note that `stop_reason` is `tool_use`, indicating that the model needs to call a
 
 ```python
 payload = {
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-5",
     "max_tokens": 1024,
     "tools": [
         {
@@ -649,7 +664,7 @@ Ace Data Cloud provides two formats of the Claude API, with the main differences
 | System Prompt    | Independent `system` field                  | Passed through `role: "system"` in `messages`          |
 | Response Structure     | `content` array (supports multiple types)             | `choices` array (contains `message`)                   |
 | Streaming Format     | SSE events (multiple event types)                   | SSE `data` lines                                 |
-| Deep Thinking     | Native `thinking` parameter                 | Triggered by special model names (e.g., `-thinking` suffix)                  |
+| Deep Thinking     | Native `thinking` parameter                 | Enabled through compatible request parameters                               |
 | Tool Invocation     | Native `tools` + `input_schema`      | OpenAI compatible `functions` format                    |
 | Token Statistics | `input_tokens` / `output_tokens` | `prompt_tokens` / `completion_tokens`        |
 


### PR DESCRIPTION
Removes retired Claude model references from current examples while retaining clearly labeled historical response snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)