### PR TITLE
docs(seedance): publish 2.5 capability parity

### DIFF
--- a/seedance/README.md
+++ b/seedance/README.md
@@ -55,6 +55,7 @@ curl --request POST "https://api.acedata.cloud/seedance/videos" \
 | Model | Generation | Notes |
 | ---- | ---- | ---- |
 | `doubao-seedance-2-5-260628` | 2.5 | Latest flagship, up to 30s, pure-audio/multimodal reference, edit/extend |
+| `doubao-seedance-2-5-260628` | 2.5 | Up to 1080p/30s, pure-audio reference, edit/extend |
 | `doubao-seedance-2-0-260128` | 2.0 | Highest resolution, multimodal reference, up to 4k |
 | `doubao-seedance-2-0-fast-260128` | 2.0 Fast | Faster 2.0, up to 720p |
 | `doubao-seedance-2-0-mini-260615` | 2.0 Mini | Lightweight / most cost-effective 2.0, up to 720p |

--- a/seedance/docs/seedance_videos_generation_api_integration_guide.md
+++ b/seedance/docs/seedance_videos_generation_api_integration_guide.md
@@ -16,6 +16,7 @@ The most basic usage is to input a `content` array containing a single text item
 
 - `model`: the model used to generate the video. Available values:
   - **Seedance 2.5**: `doubao-seedance-2-5-260628` (latest flagship, 4–30 seconds, edit/extend, pure-audio and multimodal reference).
+  - **Seedance 2.5**: `doubao-seedance-2-5-260628`, up to 1080p and 30 seconds, automatic duration, pure-audio reference, edit and extend.
   - **Seedance 2.0 series**: `doubao-seedance-2-0-260128` (standard, up to 4k), `doubao-seedance-2-0-fast-260128` (fast), `doubao-seedance-2-0-mini-260615` (lightweight).
   - **Seedance 1.x**: `doubao-seedance-1-5-pro-251215`, `doubao-seedance-1-0-pro-250528`, `doubao-seedance-1-0-pro-fast-251015`, `doubao-seedance-1-0-lite-t2v-250428`, `doubao-seedance-1-0-lite-i2v-250428`.
 - `content`: the input array. Each item carries a `type` of `text`, `image_url`, `audio_url`, or `video_url`:
@@ -23,12 +24,13 @@ The most basic usage is to input a `content` array containing a single text item
   - `image_url`: `{ "type": "image_url", "role": "first_frame|last_frame|reference_image", "image_url": { "url": "https://..." } }`.
   - `audio_url` (Seedance 2.0): `{ "type": "audio_url", "audio_url": { "url": "https://..." } }` — reference audio for voice timbre / background music.
   - `video_url` (Seedance 2.0): `{ "type": "video_url", "video_url": { "url": "https://..." } }` — reference video for subject, camera movement, motion or overall style.
-- `resolution`: output resolution, one of `480p`, `720p`, `1080p`, `4k`. `4k` is supported only by `doubao-seedance-2-0-260128`; `doubao-seedance-2-0-fast-260128` and `doubao-seedance-2-0-mini-260615` cap at `720p`. If omitted, a default resolution is selected based on the chosen model.
+- `resolution`: output resolution, one of `480p`, `720p`, `1080p`, `4k`. Seedance 2.5 supports up to `1080p`; `4k` is supported only by `doubao-seedance-2-0-260128`; `doubao-seedance-2-0-fast-260128` and `doubao-seedance-2-0-mini-260615` cap at `720p`. If omitted, a default resolution is selected based on the chosen model.
 - `ratio`: aspect ratio, one of `16:9`, `4:3`, `1:1`, `3:4`, `9:16`, `21:9`, `adaptive`. Default `16:9`.
 - `duration`: video duration in seconds, model-specific:
   - Seedance 1.0 Pro / 1.0 Pro Fast: `2`–`12`.
   - Seedance 1.5 Pro: `4`–`12`, or `-1` for automatic duration.
   - Seedance 2.0 series: `4`–`15`, or `-1` for automatic duration.
+  - Seedance 2.5: `4`–`30`, or `-1`; edit tasks require `-1`.
 - `frames`: frame count, `29`–`361` (must satisfy 25+4n). Use either `duration` or `frames`; if both are specified, `frames` takes precedence over `duration`.
 - `seed`: random seed, integer `-1`–`4294967295` (`-1` = random).
 - `camerafixed`: whether to fix the camera position, `true` / `false`.
@@ -161,3 +163,8 @@ Video generation can take time. To avoid long-held HTTP connections, use one of 
 | 500 | `internal_error` | A service processing error occurred. |
 
 Each error response includes a `trace_id` to help with debugging and support.
+
+
+## Seedance 2.5 controls
+
+Seedance 2.5 accepts up to 30 reference images, 10 videos, and 10 audios (50 media items total), including pure-audio reference. First/last-frame, edit, and extend tasks require `ratio: "adaptive"`; edit also requires `duration: -1`. Use `output_format` (`mp4`/`mov`), `return_last_frame`, `priority` (0–9), a stable anonymous `safety_identifier`, and the optional web search tool `[{"type":"web_search"}]` as needed.


### PR DESCRIPTION
## Summary
- add Seedance 2.5 to public discovery
- document 1080p, 30-second/auto duration, pure-audio reference, edit/extend, and official controls
- align model-specific resolution and duration guidance

## Dependency
Publish after PlatformService deploy and PlatformBackend DB sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)